### PR TITLE
Changed OVA location to jinja2 variable

### DIFF
--- a/playbooks/deployRouter.yml
+++ b/playbooks/deployRouter.yml
@@ -24,7 +24,7 @@
         validate_certs: no
         datastore: "{{ physicalESX.datastore }}"
         name: "{{ vm_prefix }}{{ router_hostname }}"
-        ovf: "/iso/vyos-1.1.8-amd64.ova"
+        ovf: "{{ VyosOva }}"
         networks:
           "public": "{{ router_public_pg }}"
           "internal": "{{ physicalESX.trunkpg }}"


### PR DESCRIPTION
The /iso path was hard coded in the Vyos router deployment, so if the user used a different location, the download would fail.  I went ahead and changed the hard coded "/iso" path to the variable you used in the answerfile.yml file.