### PR TITLE
Many changes (VM Naming, Netmask_cidr, vmk3, ipstorage, etc..  See comments below.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## 10-MAY-2020 by Luis Chanu
+
+### Added
+
+- Created new "nsxt_edge_uplink_1" and "nsxt_edge_uplink_2" networks (for future use)
+- Created additional "xxx_netmask_cidr" variables to replace hard coded masks found in script
+- Added new segments, includng IP storage and SVM Management, to prepare the lab for additional functionality that a lab user might want
+- Added vmk3 on nested vSphere hosts for IP Storage (should lab user need it) 
+
+### Changed
+
+- Modified nested VM naming to use Pod-###-<vm>
+- Changed hard coded cidr subnets to "xxx_netmask_cidr" variables in template files
+- To preare for NSX-T Global Manager available in v3.0, renamed NSXManager01 to "NSXT-LM", as it's now called the Local Manager
+- Changed segment offset values
+
 ## 1.2.6
 
 ### Added

--- a/answerfile_sample.yml
+++ b/answerfile_sample.yml
@@ -1,3 +1,6 @@
+# Debugging Options
+DEBUG_keep_config_files:     false       # If "true", configuration files will not be deleted from /tmp so that they can be reviewed
+
 # Deployment decisions
 deploy_router:               true   # Deploy a VyOS router for the nested environment?
 router_version:              latest # Choose between "latest" (vyos-rolling-latest) and "legacy" (vyos-1.1.8)
@@ -12,12 +15,16 @@ pod:                         230    # The pod ID should be between 10-240
 pod_network:                 "10.240"    # First 2 octets only
 
 # Networks/VLAN offsets for various services (Offset from Pod)
-vmnetwork:                   0
-management:                  1
-vmotion:                     2
-vsan:                        3
-uplink:                      4   # VLAN for BGP peering between Tier-0 and the router.
-transport:                   5   # Geneve Overlay Transport
+management:                  0
+vmotion:                     1
+vsan:                        2
+ipstorage:                   3           # Not used by the lab, but included should the lab user want to test/lab IP Storage solutions
+transport:                   4           # Geneve Overlay Transport
+svmmanagement:               5           # Not used by the lab, but included should an 3rd party solution want to be tested
+uplink:                      6           # VLAN for BGP peering between Tier-0 and the router.
+nsx_edge_uplink_1:           6           # 1st VLAN for BGP peerig between Tier-0 and the router.  (*** NOT YET IMPLEMENTED ***)
+nsx_edge_uplink_2:           7           # 2nd VLAN for BGP peerig between Tier-0 and the router.  (*** NOT YET IMPLEMENTED ***)
+vmnetwork:                   9
 
 # Paths to ISO and OVA files
 esxIso:                      "/iso/VMware-VMvisor-Installer-7.0.0-15843807.x86_64.iso"     # ESXi 7.0
@@ -58,9 +65,24 @@ dns2:                        "8.8.8.8"                                      # Yo
 ntp1:                        "10.2.129.10"                                  # Your NTP server available to the nested environment's management network
 domain:                      "lab.local"                                    # The DNS domain name for the nested environment.
 mgmt_network_mask:           "255.255.255.0"
+mgmt_network_mask_cidr:      "24"
 vmotion_network_mask:        "255.255.255.0"
+vmotion_network_mask_cidr:   "24"
 vsan_network_mask:           "255.255.255.0"
+vsan_network_mask_cidr:      "24"
+ipstorage_network_mask:      "255.255.255.0"
+ipstorage_network_mask_cidr: "24"
 transport_network_mask:      "255.255.255.0"
+transport_network_mask_cidr: "24"
+svmmanagement_network_mask:  "255.255.255.0"
+svmmanagement_network_mask_cidr:      "24"
+nsx_edge_uplink_1_network_mask:       "255.255.255.0"
+nsx_edge_uplink_1_network_mask_cidr:  "24"
+nsx_edge_uplink_2_network_mask:       "255.255.255.0"
+nsx_edge_uplink_2_network_mask_cidr:  "24"
+
+vmnetwork_network_mask:      "255.255.255.0"
+vmnetwork_network_mask_cidr: "24"
 transport_gw:                "{{ pod_network }}.{{ pod + transport }}.1"
 router_peer:                 "{{ pod_network }}.{{ pod + uplink }}.1"       # Router IP on uplink VLAN 
 uplink_ip1:                  "{{ pod_network }}.{{ pod + uplink }}.2"       # IP address of Tier-0 interface 1 on the BGP peering VLAN
@@ -74,7 +96,7 @@ vcenter:
   mask:                      "24"  
   gw:                        "{{ pod_network }}.{{ pod + management }}.1"  
   fqdn:                      "vcenter01.{{ domain }}"                       # vCenter FQDN if there is a working DNS server, otherwise specify the vCenter IP address here.
-  vmname:                    "{{ pod }}-vcenter01"  
+  vmname:                    "Pod-{{ pod }}-VCSA"  
   user:                      "administrator@vsphere.local"  
   password:                  "VMware1!"  
   datacenter:                "DC01"  
@@ -101,12 +123,14 @@ vds:
   management_pg:             "pg-management"
   vmotion_pg:                "pg-vmotion"
   vsan_pg:                   "pg-vsan"
-  vmnetwork_pg:              "pg-vmnetwork"
+  ipstorage_pg:              "pg-ipstorage"
+  svmmanagement_pg:          "pg-svm-management"
   uplink1_pg:                "pg-uplink1"
   uplink2_pg:                "pg-uplink2"
+  vmnetwork_pg:              "pg-vmnetwork"
 
 # NSX-T configuration 
-nsxmanager_name:             "nsxmanager01"
+nsxmanager_name:             "NSXT-LM"
 nsxmanpassword:              "VMware1!VMware1!"
 nsxmanaudituser:             "audit"
 nsxmanadminuser:             "admin"
@@ -133,22 +157,24 @@ nsxman:
   nsxman01:
     ip:                      "{{ pod_network }}.{{ pod + management }}.8"
     hostname:                "{{ nsxmanager_name }}.{{ domain }}"
-    vmname:                  "{{ pod }}-{{ nsxmanager_name }}"
+    vmname:                  "Pod-{{ pod }}-{{ nsxmanager_name }}"
 
 # The ESXi hosts. You can add, remove or rename ESXi hosts below.
 vESX:
-  esxi11:
+  ESXi-11:
     ip:                      "{{ pod_network }}.{{ pod + management }}.11"
     mask:                    "{{ mgmt_network_mask }}"
     gw:                      "{{ pod_network }}.{{ pod + management }}.1"
     fqdn:                    "esxi11.{{ domain }}"                        # ESXi FQDN if there is a working DNS server, otherwise specify the IP address here.
-    vmname:                  "{{ pod }}-esxi11"
+    vmname:                  "Pod-{{ pod }}-ESXi-11"
     cluster:                 "Compute-A"                                  # The cluster in the nested vSphere environment this ESXi will be added to.
     vlan:                    "{{ physicalESX.vlan }}"
     vmotion_ip:              "{{ pod_network }}.{{ pod + vmotion }}.11"
     vmotion_mask:            "{{ vmotion_network_mask }}"
     vsan_ip:                 "{{ pod_network }}.{{ pod + vsan }}.11"
     vsan_mask:               "{{ vsan_network_mask }}"
+    ipstorage_ip:            "{{ pod_network }}.{{ pod + ipstorage }}.11"
+    ipstorage_mask:          "{{ ipstorage_network_mask }}"
     username:                "root"
     password:                "VMware1!"
     cpu:                     "8"                                          # Total Number of CPUs (Must be multiple of cores)
@@ -157,18 +183,20 @@ vESX:
     boot_disk_size:          "8"
     vsan_cache_size:         "20"
     vsan_capacity_size:      "180"
-  esxi12:
+  ESXi-12:
     ip:                      "{{ pod_network }}.{{ pod + management }}.12"
     mask:                    "{{ mgmt_network_mask }}"
     gw:                      "{{ pod_network }}.{{ pod + management }}.1"
     fqdn:                    "esxi12.{{ domain }}"                        # ESXi FQDN if there is a working DNS server, otherwise specify the IP address here.
-    vmname:                  "{{ pod }}-esxi12"
+    vmname:                  "Pod-{{ pod }}-ESXi-12"
     cluster:                 "Compute-A"                                  # The cluster in the nested vSphere environment this ESXi will be added to.
     vlan:                    "{{ physicalESX.vlan }}"
     vmotion_ip:              "{{ pod_network }}.{{ pod + vmotion }}.12"
     vmotion_mask:            "{{ vmotion_network_mask }}"
     vsan_ip:                 "{{ pod_network }}.{{ pod + vsan }}.12"
     vsan_mask:               "{{ vsan_network_mask }}"
+    ipstorage_ip:            "{{ pod_network }}.{{ pod + ipstorage }}.12"
+    ipstorage_mask:          "{{ ipstorage_network_mask }}"
     username:                "root"
     password:                "VMware1!"
     cpu:                     "8"                                          # Total Number of CPUs (Must be multiple of cores)
@@ -177,18 +205,20 @@ vESX:
     boot_disk_size:          "8"
     vsan_cache_size:         "20"
     vsan_capacity_size:      "180"
-  esxi13:
+  ESXi-13:
     ip:                      "{{ pod_network }}.{{ pod + management }}.13"
     mask:                    "{{ mgmt_network_mask }}"
     gw:                      "{{ pod_network }}.{{ pod + management }}.1"
     fqdn:                    "esxi13.{{ domain }}"                        # ESXi FQDN if there is a working DNS server, otherwise specify the IP address here.
-    vmname:                  "{{ pod }}-esxi13"
+    vmname:                  "Pod-{{ pod }}-ESXi-13"
     cluster:                 "Compute-A"                                  # The cluster in the nested vSphere environment this ESXi will be added to.
     vlan:                    "{{ physicalESX.vlan }}"
     vmotion_ip:              "{{ pod_network }}.{{ pod + vmotion }}.13"
     vmotion_mask:            "{{ vmotion_network_mask }}"
     vsan_ip:                 "{{ pod_network }}.{{ pod + vsan }}.13"
     vsan_mask:               "{{ vsan_network_mask }}"
+    ipstorage_ip:            "{{ pod_network }}.{{ pod + ipstorage }}.13"
+    ipstorage_mask:          "{{ ipstorage_network_mask }}"
     username:                "root"
     password:                "VMware1!"
     cpu:                     "8"                                          # Total Number of CPUs (Must be multiple of cores)
@@ -197,18 +227,20 @@ vESX:
     boot_disk_size:          "8"
     vsan_cache_size:         "20"
     vsan_capacity_size:      "180"
-  esxi91:
+  ESXi-91:
     ip:                      "{{ pod_network }}.{{ pod + management }}.91"
     mask:                    "{{ mgmt_network_mask }}"
     gw:                      "{{ pod_network }}.{{ pod + management }}.1"
     fqdn:                    "esxi91.{{ domain }}"                        # ESXi FQDN if there is a working DNS server, otherwise specify the IP address here.
-    vmname:                  "{{ pod }}-esxi91"
+    vmname:                  "Pod-{{ pod }}-ESXi-91"
     cluster:                 "Edge"                                       # The cluster in the nested vSphere environment this ESXi will be added to.
     vlan:                    "{{ physicalESX.vlan }}"
     vmotion_ip:              "{{ pod_network }}.{{ pod + vmotion }}.91"
     vmotion_mask:            "{{ vmotion_network_mask }}"
     vsan_ip:                 "{{ pod_network }}.{{ pod + vsan }}.91"
     vsan_mask:               "{{ vsan_network_mask }}"
+    ipstorage_ip:            "{{ pod_network }}.{{ pod + ipstorage }}.91"
+    ipstorage_mask:          "{{ ipstorage_network_mask }}"
     username:                "root"
     password:                "VMware1!"
     cpu:                     "8"                                          # Total Number of CPUs (Must be multiple of cores)
@@ -217,18 +249,20 @@ vESX:
     boot_disk_size:          "8"
     vsan_cache_size:         "20"
     vsan_capacity_size:      "180"
-  esxi92:
+  ESXi-92:
     ip:                      "{{ pod_network }}.{{ pod + management }}.92"
     mask:                    "{{ mgmt_network_mask }}"
     gw:                      "{{ pod_network }}.{{ pod + management }}.1"
     fqdn:                    "esxi92.{{ domain }}"                        # ESXi FQDN if there is a working DNS server, otherwise specify the IP address here.
-    vmname:                  "{{ pod }}-esxi92"
+    vmname:                  "Pod-{{ pod }}-ESXi-92"
     cluster:                 "Edge"                                       # The cluster in the nested vSphere environment this ESXi will be added to.
     vlan:                    "{{ physicalESX.vlan }}"
     vmotion_ip:              "{{ pod_network }}.{{ pod + vmotion }}.92"
     vmotion_mask:            "{{ vmotion_network_mask }}"
     vsan_ip:                 "{{ pod_network }}.{{ pod + vsan }}.92"
     vsan_mask:               "{{ vsan_network_mask }}"
+    ipstorage_ip:            "{{ pod_network }}.{{ pod + ipstorage }}.92"
+    ipstorage_mask:          "{{ ipstorage_network_mask }}"
     username:                "root"
     password:                "VMware1!"
     cpu:                     "8"                                          # Total Number of CPUs (Must be multiple of cores)
@@ -237,18 +271,20 @@ vESX:
     boot_disk_size:          "8"
     vsan_cache_size:         "20"
     vsan_capacity_size:      "180"
-  esxi93:
+  ESXi-93:
     ip:                      "{{ pod_network }}.{{ pod + management }}.93"
     mask:                    "{{ mgmt_network_mask }}"
     gw:                      "{{ pod_network }}.{{ pod + management }}.1"
     fqdn:                    "esxi93.{{ domain }}"                        # ESXi FQDN if there is a working DNS server, otherwise specify the IP address here.
-    vmname:                  "{{ pod }}-esxi93"
+    vmname:                  "Pod-{{ pod }}-ESXi-93"
     cluster:                 "Edge"                                       # The cluster in the nested vSphere environment this ESXi will be added to.
     vlan:                    "{{ physicalESX.vlan }}"
     vmotion_ip:              "{{ pod_network }}.{{ pod + vmotion }}.93"
     vmotion_mask:            "{{ vmotion_network_mask }}"
     vsan_ip:                 "{{ pod_network }}.{{ pod + vsan }}.93"
     vsan_mask:               "{{ vsan_network_mask }}"
+    ipstorage_ip:            "{{ pod_network }}.{{ pod + ipstorage }}.93"
+    ipstorage_mask:          "{{ ipstorage_network_mask }}"
     username:                "root"
     password:                "VMware1!"
     cpu:                     "8"                                          # Total Number of CPUs (Must be multiple of cores)

--- a/answerfile_sample.yml
+++ b/answerfile_sample.yml
@@ -136,7 +136,7 @@ nsxmanaudituser:             "audit"
 nsxmanadminuser:             "admin"
 nsxmansize:                  "small"
 nsxmanrole:                  "NSX Manager"
-nsxlicense:                  "/tmp/nsxlicense.txt"   # Path to the NSX-T license key file (text file should contain just the key).
+nsxlicense:                  "/tmp/nsxlicense.txt"                  # Path to the NSX-T license key file (text file should contain just the key).
 nvds_name:                   "n-vds01"              
 tz_vlan_name:                "tz-vlan"              
 tz_overlay_name:             "tz-overlay"              
@@ -145,10 +145,10 @@ ip_pool_name:                "tep-pool"
 tn_profile_name:             "esxi-tnp"              
 edge_node1:                  "en01"              
 edge_node2:                  "en02"              
-edge_node_vsphere_cluster:   "Edge"                  # The vSphere cluster in the nested environment where the Edge VMs should be deployed.
-edge_node1_vesxi:            "esxi91.{{ domain }}"   # The nested ESXi host where Edge VM 1 should be placed. Specify IP address if there's no working DNS. 
-edge_node2_vesxi:            "esxi92.{{ domain }}"   # The nested ESXi host where Edge VM 2 should be placed. Specify IP address if there's no working DNS.
-edge_cluster_name:           "edge-cluster-01"       # The NSX-T Edge Cluster
+edge_node_vsphere_cluster:   "Edge"                                 # The vSphere cluster in the nested environment where the Edge VMs should be deployed.
+edge_node1_vesxi:            "Pod-{{ pod }}-ESXi-91.{{ domain }}"   # The nested ESXi host where Edge VM 1 should be placed. Specify IP address if there's no working DNS. 
+edge_node2_vesxi:            "Pod-{{ pod }}-ESXi-92.{{ domain }}"   # The nested ESXi host where Edge VM 2 should be placed. Specify IP address if there's no working DNS.
+edge_cluster_name:           "edge-cluster-01"                      # The NSX-T Edge Cluster
 edgepassword:                "VMware1!VMware1!"
 tier0_name:                  "tier-0"
 
@@ -165,7 +165,7 @@ vESX:
     ip:                      "{{ pod_network }}.{{ pod + management }}.11"
     mask:                    "{{ mgmt_network_mask }}"
     gw:                      "{{ pod_network }}.{{ pod + management }}.1"
-    fqdn:                    "esxi11.{{ domain }}"                        # ESXi FQDN if there is a working DNS server, otherwise specify the IP address here.
+    fqdn:                    "Pod-{{ pod }}-ESXi-11.{{ domain }}"         # ESXi FQDN if there is a working DNS server, otherwise specify the IP address here.
     vmname:                  "Pod-{{ pod }}-ESXi-11"
     cluster:                 "Compute-A"                                  # The cluster in the nested vSphere environment this ESXi will be added to.
     vlan:                    "{{ physicalESX.vlan }}"
@@ -187,7 +187,7 @@ vESX:
     ip:                      "{{ pod_network }}.{{ pod + management }}.12"
     mask:                    "{{ mgmt_network_mask }}"
     gw:                      "{{ pod_network }}.{{ pod + management }}.1"
-    fqdn:                    "esxi12.{{ domain }}"                        # ESXi FQDN if there is a working DNS server, otherwise specify the IP address here.
+    fqdn:                    "Pod-{{ pod }}-ESXi-12.{{ domain }}"         # ESXi FQDN if there is a working DNS server, otherwise specify the IP address here.
     vmname:                  "Pod-{{ pod }}-ESXi-12"
     cluster:                 "Compute-A"                                  # The cluster in the nested vSphere environment this ESXi will be added to.
     vlan:                    "{{ physicalESX.vlan }}"
@@ -209,7 +209,7 @@ vESX:
     ip:                      "{{ pod_network }}.{{ pod + management }}.13"
     mask:                    "{{ mgmt_network_mask }}"
     gw:                      "{{ pod_network }}.{{ pod + management }}.1"
-    fqdn:                    "esxi13.{{ domain }}"                        # ESXi FQDN if there is a working DNS server, otherwise specify the IP address here.
+    fqdn:                    "Pod-{{ pod }}-ESXi-13.{{ domain }}"         # ESXi FQDN if there is a working DNS server, otherwise specify the IP address here.
     vmname:                  "Pod-{{ pod }}-ESXi-13"
     cluster:                 "Compute-A"                                  # The cluster in the nested vSphere environment this ESXi will be added to.
     vlan:                    "{{ physicalESX.vlan }}"
@@ -231,7 +231,7 @@ vESX:
     ip:                      "{{ pod_network }}.{{ pod + management }}.91"
     mask:                    "{{ mgmt_network_mask }}"
     gw:                      "{{ pod_network }}.{{ pod + management }}.1"
-    fqdn:                    "esxi91.{{ domain }}"                        # ESXi FQDN if there is a working DNS server, otherwise specify the IP address here.
+    fqdn:                    "Pod-{{ pod }}-ESXi-91.{{ domain }}"         # ESXi FQDN if there is a working DNS server, otherwise specify the IP address here.
     vmname:                  "Pod-{{ pod }}-ESXi-91"
     cluster:                 "Edge"                                       # The cluster in the nested vSphere environment this ESXi will be added to.
     vlan:                    "{{ physicalESX.vlan }}"
@@ -253,7 +253,7 @@ vESX:
     ip:                      "{{ pod_network }}.{{ pod + management }}.92"
     mask:                    "{{ mgmt_network_mask }}"
     gw:                      "{{ pod_network }}.{{ pod + management }}.1"
-    fqdn:                    "esxi92.{{ domain }}"                        # ESXi FQDN if there is a working DNS server, otherwise specify the IP address here.
+    fqdn:                    "Pod-{{ pod }}-ESXi-92.{{ domain }}"         # ESXi FQDN if there is a working DNS server, otherwise specify the IP address here.
     vmname:                  "Pod-{{ pod }}-ESXi-92"
     cluster:                 "Edge"                                       # The cluster in the nested vSphere environment this ESXi will be added to.
     vlan:                    "{{ physicalESX.vlan }}"
@@ -275,7 +275,7 @@ vESX:
     ip:                      "{{ pod_network }}.{{ pod + management }}.93"
     mask:                    "{{ mgmt_network_mask }}"
     gw:                      "{{ pod_network }}.{{ pod + management }}.1"
-    fqdn:                    "esxi93.{{ domain }}"                        # ESXi FQDN if there is a working DNS server, otherwise specify the IP address here.
+    fqdn:                    "Pod-{{ pod }}-ESXi-93.{{ domain }}"         # ESXi FQDN if there is a working DNS server, otherwise specify the IP address here.
     vmname:                  "Pod-{{ pod }}-ESXi-93"
     cluster:                 "Edge"                                       # The cluster in the nested vSphere environment this ESXi will be added to.
     vlan:                    "{{ physicalESX.vlan }}"

--- a/playbooks/createVds.yml
+++ b/playbooks/createVds.yml
@@ -57,6 +57,32 @@
         portgroup_type: earlyBinding
         state: present
 
+    - name: Create IP Storage port group
+      vmware_dvs_portgroup:
+        hostname: "{{ vcenter.ip }}"
+        username: "{{ vcenter.user }}"
+        password: "{{ vcenter.password }}"
+        validate_certs: false
+        portgroup_name: "{{ vds.ipstorage_pg }}"
+        switch_name: "{{ vds.name }}"
+        vlan_id: "{{ pod + ipstorage }}"
+        num_ports: 8
+        portgroup_type: earlyBinding
+        state: present
+
+    - name: Create SVM-Management port group
+      vmware_dvs_portgroup:
+        hostname: "{{ vcenter.ip }}"
+        username: "{{ vcenter.user }}"
+        password: "{{ vcenter.password }}"
+        validate_certs: false
+        portgroup_name: "{{ vds.svmmanagement_pg }}"
+        switch_name: "{{ vds.name }}"
+        vlan_id: "{{ pod + ipstorage }}"
+        num_ports: 8
+        portgroup_type: earlyBinding
+        state: present
+
     - name: Create vmnetwork port group
       vmware_dvs_portgroup:
         hostname: "{{ vcenter.ip }}"
@@ -133,7 +159,7 @@
         username: "{{ vcenter.user }}"
         password: "{{ vcenter.password }}"
         state: present
-        portgroup_name: 'pg-vmotion'
+        portgroup_name: "{{ vds.vmotion_pg }}"
         dvswitch_name: "{{ vds.name }}"
         validate_certs: False
         enable_vmotion: true
@@ -152,13 +178,29 @@
         password: "{{ vcenter.password }}"
         state: present
         enable_vsan: true
-        portgroup_name: 'pg-vsan'
+        portgroup_name: "{{ vds.vsan_pg }}"
         dvswitch_name: "{{ vds.name }}"
         validate_certs: False
         network:
           type: 'static'
           ip_address: "{{ item.value.vsan_ip }}"
           subnet_mask: "{{ item.value.vsan_mask }}"
+      with_dict: "{{ vESX }}"
+      
+    - name: Create vmk3 for IP Storage
+      vmware_vmkernel:
+        hostname: "{{ vcenter.ip }}"
+        esxi_hostname: "{{ item.value.fqdn }}"
+        username: "{{ vcenter.user }}"
+        password: "{{ vcenter.password }}"
+        state: present
+        portgroup_name: "{{ vds.ipstorage_pg }}"
+        dvswitch_name: "{{ vds.name }}"
+        validate_certs: False
+        network:
+          type: 'static'
+          ip_address: "{{ item.value.ipstorage_ip }}"
+          subnet_mask: "{{ item.value.ipstorage_mask }}"
       with_dict: "{{ vESX }}"
       
     - name: Remove the standard switch from the ESXi hosts

--- a/playbooks/deployRouter.yml
+++ b/playbooks/deployRouter.yml
@@ -11,7 +11,7 @@
         password: "{{ physicalESX.password }}"
         validate_certs: no
         datacenter: "ha-datacenter"
-        name: "{{ pod }}-{{ router_hostname }}"
+        name: "Pod-{{ pod }}-{{ router_hostname }}"
         schema: "vsphere"
         properties: ["overallStatus"]
       delegate_to: localhost
@@ -44,7 +44,7 @@
         password: "{{ physicalESX.password }}"
         validate_certs: no
         datastore: "{{ physicalESX.datastore }}"
-        name: "{{ pod }}-{{ router_hostname }}"
+        name: "Pod-{{ pod }}-{{ router_hostname }}"
         ovf: "{{ VyosOva }}"
         networks:
           "public": "{{ router_public_pg }}"
@@ -65,7 +65,7 @@
         username: "{{ physicalESX.user }}"
         password: "{{ physicalESX.password }}"
         validate_certs: no
-        vm_id: "{{ pod }}-{{ router_hostname }}"
+        vm_id: "Pod-{{ pod }}-{{ router_hostname }}"
         vm_username: "vyos"
         vm_password: "vyos"
         copy:
@@ -83,7 +83,7 @@
         username: "{{ physicalESX.user }}"
         password: "{{ physicalESX.password }}"
         validate_certs: no
-        name: "{{ pod }}-{{ router_hostname }}"
+        name: "Pod-{{ pod }}-{{ router_hostname }}"
         annotation: "The password for the vyos user is VMware1!"
       when: 
         - deploy_router == true
@@ -96,7 +96,7 @@
         username: "{{ physicalESX.user }}"
         password: "{{ physicalESX.password }}"
         validate_certs: no
-        name: "{{ pod }}-{{ router_hostname }}"
+        name: "Pod-{{ pod }}-{{ router_hostname }}"
         state: reboot-guest
       when: 
         - deploy_router == true
@@ -116,7 +116,9 @@
 
     - name: Delete the temporary template file for VyOS router
       file: path=/tmp/vyos.conf state=absent
-      when: deploy_router == true
+      when: 
+        - deploy_router == true
+        - DEBUG_keep_config_files != true
 
     - name: Wait 10 seconds
       pause: seconds=10

--- a/playbooks/deployRouterIso.yml
+++ b/playbooks/deployRouterIso.yml
@@ -11,7 +11,7 @@
         password: "{{ physicalESX.password }}"
         validate_certs: no
         datacenter: "ha-datacenter"
-        name: "{{ pod }}-{{ router_hostname }}"
+        name: "Pod-{{ pod }}-{{ router_hostname }}"
         schema: "vsphere"
         properties: ["overallStatus"]
       delegate_to: localhost
@@ -59,7 +59,7 @@
         username: "{{ physicalESX.user }}"
         password: "{{ physicalESX.password }}"
         validate_certs: no
-        name: "{{ pod }}-{{ router_hostname }}"
+        name: "Pod-{{ pod }}-{{ router_hostname }}"
         state: poweredon
         guest_id: debian10_64Guest
         esxi_hostname: "{{ physicalESX.fqdn }}"
@@ -99,7 +99,7 @@
         username: "{{ physicalESX.user }}"
         password: "{{ physicalESX.password }}"
         validate_certs: no
-        name: "{{ pod }}-{{ router_hostname }}"
+        name: "Pod-{{ pod }}-{{ router_hostname }}"
         string_send: "vyos"
       when: 
         - deploy_router == true
@@ -119,7 +119,7 @@
         username: "{{ physicalESX.user }}"
         password: "{{ physicalESX.password }}"
         validate_certs: no
-        name: "{{ pod }}-{{ router_hostname }}"
+        name: "Pod-{{ pod }}-{{ router_hostname }}"
         keys_send:
           - ENTER
       when: 
@@ -140,7 +140,7 @@
         username: "{{ physicalESX.user }}"
         password: "{{ physicalESX.password }}"
         validate_certs: no
-        name: "{{ pod }}-{{ router_hostname }}"
+        name: "Pod-{{ pod }}-{{ router_hostname }}"
         string_send: "vyos"
       when: 
         - deploy_router == true
@@ -160,7 +160,7 @@
         username: "{{ physicalESX.user }}"
         password: "{{ physicalESX.password }}"
         validate_certs: no
-        name: "{{ pod }}-{{ router_hostname }}"
+        name: "Pod-{{ pod }}-{{ router_hostname }}"
         keys_send:
           - ENTER
       when: 
@@ -181,7 +181,7 @@
         username: "{{ physicalESX.user }}"
         password: "{{ physicalESX.password }}"
         validate_certs: no
-        name: "{{ pod }}-{{ router_hostname }}"
+        name: "Pod-{{ pod }}-{{ router_hostname }}"
         string_send: "install image"
       when: 
         - deploy_router == true
@@ -201,7 +201,7 @@
         username: "{{ physicalESX.user }}"
         password: "{{ physicalESX.password }}"
         validate_certs: no
-        name: "{{ pod }}-{{ router_hostname }}"
+        name: "Pod-{{ pod }}-{{ router_hostname }}"
         keys_send:
           - ENTER
           - ENTER
@@ -225,7 +225,7 @@
         username: "{{ physicalESX.user }}"
         password: "{{ physicalESX.password }}"
         validate_certs: no
-        name: "{{ pod }}-{{ router_hostname }}"
+        name: "Pod-{{ pod }}-{{ router_hostname }}"
         string_send: "yes"
       when: 
         - deploy_router == true
@@ -245,7 +245,7 @@
         username: "{{ physicalESX.user }}"
         password: "{{ physicalESX.password }}"
         validate_certs: no
-        name: "{{ pod }}-{{ router_hostname }}"
+        name: "Pod-{{ pod }}-{{ router_hostname }}"
         keys_send:
           - ENTER
           - ENTER
@@ -269,7 +269,7 @@
         username: "{{ physicalESX.user }}"
         password: "{{ physicalESX.password }}"
         validate_certs: no
-        name: "{{ pod }}-{{ router_hostname }}"
+        name: "Pod-{{ pod }}-{{ router_hostname }}"
         string_send: "vyos"
       when: 
         - deploy_router == true
@@ -289,7 +289,7 @@
         username: "{{ physicalESX.user }}"
         password: "{{ physicalESX.password }}"
         validate_certs: no
-        name: "{{ pod }}-{{ router_hostname }}"
+        name: "Pod-{{ pod }}-{{ router_hostname }}"
         keys_send:
           - ENTER
       when: 
@@ -310,7 +310,7 @@
         username: "{{ physicalESX.user }}"
         password: "{{ physicalESX.password }}"
         validate_certs: no
-        name: "{{ pod }}-{{ router_hostname }}"
+        name: "Pod-{{ pod }}-{{ router_hostname }}"
         string_send: "vyos"
       when: 
         - deploy_router == true
@@ -330,7 +330,7 @@
         username: "{{ physicalESX.user }}"
         password: "{{ physicalESX.password }}"
         validate_certs: no
-        name: "{{ pod }}-{{ router_hostname }}"
+        name: "Pod-{{ pod }}-{{ router_hostname }}"
         keys_send:
           - ENTER
       when: 
@@ -351,7 +351,7 @@
         username: "{{ physicalESX.user }}"
         password: "{{ physicalESX.password }}"
         validate_certs: no
-        name: "{{ pod }}-{{ router_hostname }}"
+        name: "Pod-{{ pod }}-{{ router_hostname }}"
         keys_send:
           - ENTER
       when: 
@@ -372,7 +372,7 @@
         username: "{{ physicalESX.user }}"
         password: "{{ physicalESX.password }}"
         validate_certs: no
-        name: "{{ pod }}-{{ router_hostname }}"
+        name: "Pod-{{ pod }}-{{ router_hostname }}"
         state: reboot-guest
       when: 
         - deploy_router == true
@@ -392,7 +392,7 @@
         username: "{{ physicalESX.user }}"
         password: "{{ physicalESX.password }}"
         validate_certs: no
-        vm_id: "{{ pod }}-{{ router_hostname }}"
+        vm_id: "Pod-{{ pod }}-{{ router_hostname }}"
         vm_username: "vyos"
         vm_password: "vyos"
         copy:
@@ -410,7 +410,7 @@
         username: "{{ physicalESX.user }}"
         password: "{{ physicalESX.password }}"
         validate_certs: no
-        name: "{{ pod }}-{{ router_hostname }}"
+        name: "Pod-{{ pod }}-{{ router_hostname }}"
         annotation: "The password for the vyos user is VMware1!"
       when: 
         - deploy_router == true
@@ -423,7 +423,7 @@
         username: "{{ physicalESX.user }}"
         password: "{{ physicalESX.password }}"
         validate_certs: no
-        name: "{{ pod }}-{{ router_hostname }}"
+        name: "Pod-{{ pod }}-{{ router_hostname }}"
         state: shutdown-guest
       when: 
         - deploy_router == true
@@ -443,7 +443,7 @@
         username: "{{ physicalESX.user }}"
         password: "{{ physicalESX.password }}"
         validate_certs: no
-        name: "{{ pod }}-{{ router_hostname }}"
+        name: "Pod-{{ pod }}-{{ router_hostname }}"
         cdrom:
           type: "none"
       when: 
@@ -457,7 +457,7 @@
         username: "{{ physicalESX.user }}"
         password: "{{ physicalESX.password }}"
         validate_certs: no
-        name: "{{ pod }}-{{ router_hostname }}"
+        name: "Pod-{{ pod }}-{{ router_hostname }}"
         state: powered-on
       when: 
         - deploy_router == true
@@ -481,6 +481,7 @@
         - deploy_router == true
         - status is failed
         - router_version == "latest"
+        - DEBUG_keep_config_files != true
 
     - name: Wait 10 seconds
       pause: seconds=10

--- a/templates/vyos.conf
+++ b/templates/vyos.conf
@@ -10,35 +10,50 @@ interfaces {
         mtu 9000
         smp_affinity auto
         speed auto
-        vif {{ pod + vmnetwork }} {
-            address {{ pod_network }}.{{ pod + vmnetwork }}.1/24
-            description "VM network"
-            mtu 1500
-        }
         vif {{ physicalESX.vlan }} {
-            address {{ pod_network }}.{{ pod + management }}.1/24
+            address {{ pod_network }}.{{ pod + management }}.1/{{ mgmt_network_mask_cidr }}
             description Management
             mtu 1500
         }
         vif {{ pod + vmotion }} {
-            address {{ pod_network }}.{{ pod + vmotion }}.1/24
+            address {{ pod_network }}.{{ pod + vmotion }}.1/{{ vmotion_network_mask_cidr }}
             description vMotion
             mtu 9000
         }
         vif {{ pod + vsan }} {
-            address {{ pod_network }}.{{ pod + vsan }}.1/24
+            address {{ pod_network }}.{{ pod + vsan }}.1/{{ vsan_network_mask_cidr }}
             description vSAN
             mtu 9000
+        }
+        vif {{ pod + ipstorage }} {
+            address {{ pod_network }}.{{ pod + ipstorage }}.1/{{ ipstorage_network_mask_cidr }}
+            description "IP Storage"
+            mtu 9000
+        }
+        vif {{ pod + transport }} {
+            address {{ transport_gw }}/{{ transport_network_mask_cidr }}
+            description "Overlay transport"
+            mtu 9000
+        }
+        vif {{ pod + svmmanagement }} {
+            address {{ pod_network }}.{{ pod + svmmanagement }}.1/{{ svmmanagement_network_mask_cidr }}
+            description "Service VM Management"
+            mtu 1500
         }
         vif {{ pod + uplink }} {
             address {{ router_peer }}/24
             description Uplink
             mtu 1500
         }
-        vif {{ pod + transport }} {
-            address {{ transport_gw }}/24
-            description "Overlay transport"
-            mtu 9000
+        vif {{ pod + nsx_edge_uplink_2 }} {
+            address {{ pod_network }}.{{ pod + nsx_edge_uplink_2 }}.1/{{nsx_edge_uplink_2_network_mask_cidr }} 
+            description "NSX Edge Uplink #2"
+            mtu 1500
+        }
+        vif {{ pod + vmnetwork }} {
+            address {{ pod_network }}.{{ pod + vmnetwork }}.1/{{ vmnetwork_network_mask_cidr }}
+            description "VM network"
+            mtu 1500
         }
     }
     loopback lo {
@@ -49,7 +64,7 @@ nat {
         rule 1 {
             outbound-interface eth0
             source {
-                address {{ pod_network }}.{{ pod + management }}.0/24
+                address {{ pod_network }}.{{ pod + management }}.0/{{ mgmt_network_mask_cidr }}
             }
             translation {
                 address masquerade
@@ -58,7 +73,7 @@ nat {
         rule 2 {
             outbound-interface eth0
             source {
-                address {{ pod_network }}.{{ pod + vmnetwork }}.0/24
+                address {{ pod_network }}.{{ pod + vmnetwork }}.0/{{ vmnetwork_network_mask_cidr }}
             }
             translation {
                 address masquerade
@@ -94,7 +109,7 @@ service {
         disabled false
         shared-network-name vmnetwork {
             authoritative enable
-            subnet {{ pod_network }}.{{ pod + vmnetwork }}.0/24 {
+            subnet {{ pod_network }}.{{ pod + vmnetwork }}.0/{{ vmnetwork_network_mask_cidr }} {
                 default-router {{ pod_network }}.{{ pod + vmnetwork }}.1
                 dns-server {{ dns1 }}
                 lease 300
@@ -114,7 +129,7 @@ system {
     }
     console {
     }
-    host-name {{ router_hostname }}
+    host-name Pod-{{ pod }}-{{ router_hostname }}
     login {
         user vyos {
             authentication {

--- a/templates/vyos_rolling_release.conf
+++ b/templates/vyos_rolling_release.conf
@@ -10,35 +10,50 @@ interfaces {
         mtu 9000
         smp_affinity auto
         speed auto
-        vif {{ pod + vmnetwork }} {
-            address {{ pod_network }}.{{ pod + vmnetwork }}.1/24
-            description "VM network"
-            mtu 1500
-        }
         vif {{ physicalESX.vlan }} {
-            address {{ pod_network }}.{{ pod + management }}.1/24
+            address {{ pod_network }}.{{ pod + management }}.1/{{ mgmt_network_mask_cidr }}
             description Management
             mtu 1500
         }
         vif {{ pod + vmotion }} {
-            address {{ pod_network }}.{{ pod + vmotion }}.1/24
+            address {{ pod_network }}.{{ pod + vmotion }}.1/{{ vmotion_network_mask_cidr }}
             description vMotion
             mtu 9000
         }
         vif {{ pod + vsan }} {
-            address {{ pod_network }}.{{ pod + vsan }}.1/24
+            address {{ pod_network }}.{{ pod + vsan }}.1/{{ vsan_network_mask_cidr }}
             description vSAN
             mtu 9000
+        }
+        vif {{ pod + ipstorage }} {
+            address {{ pod_network }}.{{ pod + ipstorage }}.1/{{ ipstorage_network_mask_cidr }}
+            description "IP Storage"
+            mtu 9000
+        }
+        vif {{ pod + transport }} {
+            address {{ transport_gw }}/{{ transport_network_mask_cidr }}
+            description "Overlay transport"
+            mtu 9000
+        }
+        vif {{ pod + svmmanagement }} {
+            address {{ pod_network }}.{{ pod + svmmanagement }}.1/{{ svmmanagement_network_mask_cidr }}
+            description "Service VM Management"
+            mtu 1500
         }
         vif {{ pod + uplink }} {
             address {{ router_peer }}/24
             description Uplink
             mtu 1500
         }
-        vif {{ pod + transport }} {
-            address {{ transport_gw }}/24
-            description "Overlay transport"
-            mtu 9000
+        vif {{ pod + nsx_edge_uplink_2 }} {
+            address {{ pod_network }}.{{ pod + nsx_edge_uplink_2 }}.1/{{nsx_edge_uplink_2_network_mask_cidr }}
+            description "NSX Edge Uplink #2"
+            mtu 1500
+        }
+        vif {{ pod + vmnetwork }} {
+            address {{ pod_network }}.{{ pod + vmnetwork }}.1/{{ vmnetwork_network_mask_cidr }}
+            description "VM network"
+            mtu 1500
         }
     }
     loopback lo {
@@ -49,7 +64,7 @@ nat {
         rule 1 {
             outbound-interface eth0
             source {
-                address {{ pod_network }}.{{ pod + management }}.0/24
+                address {{ pod_network }}.{{ pod + management }}.0/{{ mgmt_network_mask_cidr }}
             }
             translation {
                 address masquerade
@@ -58,7 +73,7 @@ nat {
         rule 2 {
             outbound-interface eth0
             source {
-                address {{ pod_network }}.{{ pod + vmnetwork }}.0/24
+                address {{ pod_network }}.{{ pod + vmnetwork }}.0/{{ vmnetwork_network_mask_cidr }}
             }
             translation {
                 address masquerade
@@ -94,7 +109,7 @@ service {
         disabled false
         shared-network-name vmnetwork {
             authoritative enable
-            subnet {{ pod_network }}.{{ pod + vmnetwork }}.0/24 {
+            subnet {{ pod_network }}.{{ pod + vmnetwork }}.0/{{ vmnetwork_network_mask_cidr }} {
                 default-router {{ pod_network }}.{{ pod + vmnetwork }}.1
                 dns-server {{ dns1 }}
                 lease 300
@@ -114,7 +129,7 @@ system {
     }
     console {
     }
-    host-name {{ router_hostname }}
+    host-name Pod-{{ pod }}-{{ router_hostname }}
     login {
         user vyos {
             authentication {

--- a/undeploy.yml
+++ b/undeploy.yml
@@ -11,7 +11,7 @@
         username: "{{ physicalESX.user }}"
         password: "{{ physicalESX.password }}"
         validate_certs: no
-        name: "{{ pod }}-{{ router_hostname }}"
+        name: "Pod-{{ pod }}-{{ router_hostname }}"
         force: true
         state: absent
       async: 7200


### PR DESCRIPTION
The changes in this pull request include:
    1. Modified nested VM naming to use Pod-###-<vm>
    2. Created additional netmask_cidr variables
    3. Changed hard coded subnets to variables in templates
    4. Changed segment offset values
    5. Created new "nsxt_edge_uplink_1" and "nsxt_edge_uplink_2" networks (for future use)
    6. Added new segments, includng IP storage and SVM Management
    7. Added vmk3 on nested vSphere hosts for IP Storage (should lab user need it)