### PR TITLE
Added OSPF uplink peering support to Vyos router

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## TBD 19-MAY-2020 by Luis Chanu
+
+### Added
+
+- Support for Vyos router to peer with physical environment over OSPFv2 to share internal routes.  This removes the need to install static routes.
+- Ansible modules are now requiring the netaddr library, which can be added via "pip3 install netaddr" on the Ansible control station.
+- Added small "router" data structure into answerfile_sample.yml to provide required dynamic routing informaiton.
+- Added Jinja2 conditional logic around OSPF and Static configuration so that only the requested configuration is deployed.
+- New variable called "router.protocol" controls if deployment uses static routing or OSPF.  Variable is set to either "static" or "ospf".
+
+### Changed
+
+- Answerfile_sample.yml variable values were modified to align configuration with "standard" OSPF deployment testbed.
+- Modified BGP "router-id" value so that the 3rd octet matches the Pod #, making it easier to identify.
+- Set the OSPF "router-id" value to match the IP address of the uplink Vyos router interface, thus making it easier to identify which Vyos instance an entry is referring to from the OSPF process running on the physical lab switch.
+
+
 ## 1.2.8 15-MAY-2020 by Rutger Blom
 
 ### Added

--- a/answerfile_sample.yml
+++ b/answerfile_sample.yml
@@ -12,7 +12,7 @@ use_nfs:                     false   # Mount an existing NFS datastore to the ne
 pod:                         230    # The pod ID should be between 10-240
 
 # Pod Network prefix (First 2 octets of Pod Networks)
-pod_network:                 "10.240"    # First 2 octets only
+pod_network:                 "10.203"    # First 2 octets only
 
 # Networks/VLAN offsets for various services (Offset from Pod)
 management:                  0
@@ -54,11 +54,18 @@ nfs_path:                    "/nested_nfs01"           # NFS path
 nfs_type:                    "nfs"                     # NFS version 3
 
 # VyOS router configuration
-router_hostname:             "router01"
-router_public_ip:            "10.2.129.101/24"                        # CIDR notation. Should be an IP address in the same subnet as your Ansible control node.
-router_default_gw:           "10.2.129.1"                             # IP address of the next-hop on your physical network (upstream router)
+router_hostname:             "Router"
+router_public_ip:            "10.203.0.{{ pod }}/24"                  # CIDR notation. Should be an IP address in the same subnet as your Ansible control node.
+router_default_gw:           "10.203.0.1"                             # IP address of the next-hop on your physical network (upstream router)
 router_public_pg:            "pg-management"                          # Change this to an existing port group for the router's public interface.
+router_as:                   "65000"                                  # BGP AS number on your router (VyOS if deploy_router == true)
 router_vmname:               "Pod-{{ pod }}-{{ router_hostname }}"
+
+router:
+  protocol: ospf                                                      # Either "static" or "ospf" are supported
+  ospf:
+    area: 666                                                         # specify OSPF area for uplink peering connction
+
 
 # Some global network properties for the nested environment
 dns1:                        "10.2.129.10"                                  # Your primary DNS server available to the nested environment.
@@ -81,15 +88,14 @@ nsx_edge_uplink_1_network_mask:       "255.255.255.0"
 nsx_edge_uplink_1_network_mask_cidr:  "24"
 nsx_edge_uplink_2_network_mask:       "255.255.255.0"
 nsx_edge_uplink_2_network_mask_cidr:  "24"
-
 vmnetwork_network_mask:      "255.255.255.0"
 vmnetwork_network_mask_cidr: "24"
+
 transport_gw:                "{{ pod_network }}.{{ pod + transport }}.1"
 router_peer:                 "{{ pod_network }}.{{ pod + uplink }}.1"       # Router IP on uplink VLAN 
 uplink_ip1:                  "{{ pod_network }}.{{ pod + uplink }}.2"       # IP address of Tier-0 interface 1 on the BGP peering VLAN
 uplink_ip2:                  "{{ pod_network }}.{{ pod + uplink }}.3"       # IP address of Tier-0 interface 2 on the BGP peering VLAN
 nsx_as:                      "65{{ pod }}"                                  # BGP AS number on the NSX-T side
-router_as:                   "65000"                                        # BGP AS number on your router (VyOS if deploy_router == true)
 
 # New vCenter appliance configuration
 vcenter:

--- a/playbooks/deployRouter.yml
+++ b/playbooks/deployRouter.yml
@@ -477,6 +477,7 @@
       ignore_errors: true
       when: 
         - deploy_router == true
+        - router.protocol == "static"
         - status is failed
 
     - name: Wait 10 seconds

--- a/templates/vyos.conf
+++ b/templates/vyos.conf
@@ -94,15 +94,34 @@ protocols {
             remote-as {{ nsx_as }}
         }
         parameters {
-            router-id {{ router_peer }}
+            router-id {{ pod_network }}.{{ pod }}.1
         }
     }
+{% if router.protocol == "ospf" %}
+    ospf {
+        area {{ router.ospf.area }} {
+            network {{ router_public_ip | ipaddr('network/prefix') }}
+        }
+        log-adjacency-changes {
+        }
+        parameters {
+            router-id {{ router_public_ip.split("/")[0] }}
+        }
+        redistribute {
+            connected {
+                metric-type 2
+            }
+        }
+    }
+{% endif %}
+{% if router.protocol == "static" %}
     static {
         route 0.0.0.0/0 {
             next-hop {{ router_default_gw }} {
             }
         }
     }
+{% endif %}
 }
 service {
     dhcp-server {

--- a/templates/vyos_rolling_release.conf
+++ b/templates/vyos_rolling_release.conf
@@ -94,15 +94,34 @@ protocols {
             remote-as {{ nsx_as }}
         }
         parameters {
-            router-id {{ router_peer }}
+            router-id {{ pod_network }}.{{ pod }}.1
         }
     }
+{% if router.protocol == "ospf" %}
+    ospf {
+        area {{ router.ospf.area }} {
+            network {{ router_public_ip | ipaddr('network/prefix') }}
+        }
+        log-adjacency-changes {
+        }
+        parameters {
+            router-id {{ router_public_ip.split("/")[0] }}
+        }
+        redistribute {
+            connected {
+                metric-type 2
+            }
+        }
+    }
+{% endif %}
+{% if router.protocol == "static" %}
     static {
         route 0.0.0.0/0 {
             next-hop {{ router_default_gw }} {
             }
         }
     }
+{% endif %}
 }
 service {
     dhcp-server {


### PR DESCRIPTION
Added OSPF support to Vyos router.  Tests are currently running, but it's past the Vyos deployment section, and it completed sucessfully, and is continuing to run.  I tested the creation and deployment of the Vyos configuration files under both OSPF and Static deployment scenarios, and they worked fine (Just "deployRouter.yml" was run).  Please run it through your tests as well.  I did my best to manually update the answerfile_sample.yml file with all the new elements, so I hope I didn't miss anything.  If so, please advise.