### PR TITLE
Added CD-ROM removal from ESXi nested hosts and corrected Vyos configuration

### DIFF
--- a/answerfile_sample.yml
+++ b/answerfile_sample.yml
@@ -165,7 +165,7 @@ tier0_name:                  "tier-0"
 nsxman:
   nsxman01:
     ip:                      "{{ pod_network }}.{{ pod + management }}.8"
-    hostname:                "{{ nsxmanager_name }}.{{ domain }}"
+    hostname:                "Pod-{{ pod }}-{{ nsxmanager_name }}.{{ domain }}"
     vmname:                  "Pod-{{ pod }}-{{ nsxmanager_name }}"
 
 # The ESXi hosts. You can add, remove or rename ESXi hosts below.

--- a/playbooks/deployNestedEsxi.yml
+++ b/playbooks/deployNestedEsxi.yml
@@ -81,4 +81,29 @@
       until: job_result.finished
       with_items: "{{ deployment.results }}"
       retries: 20         
+
+    - name: Disconnect CD-ROM from Nested ESXi VMs
+      vmware_guest:
+        hostname: "{{ physicalESX.fqdn }}"
+        username: "{{ physicalESX.user }}"
+        password: "{{ physicalESX.password }}"
+        validate_certs: no
+        name: "{{ item.value.vmname }}"
+        cdrom:
+          type: "none"
+      with_dict: "{{ vESX }}"
+      async: 7200
+      poll: 0
+
+    - name: Delete Custom ESXi ISO image used for Pod ESXi deployment
+      vsphere_file:
+        hostname: "{{ physicalESX.fqdn }}"
+        username: "{{ physicalESX.user}}"
+        password: "{{ physicalESX.password }}"
+        validate_certs: no
+        datacenter: /ha-datacenter
+        datastore: "{{ physicalESX.datastore }}"
+        path: "/rutgerISO/customesxv.iso"
+        state: absent
+      delegate_to: localhost
   tags: nestedESX

--- a/playbooks/deployRouter.yml
+++ b/playbooks/deployRouter.yml
@@ -382,7 +382,7 @@
         vm_username: "vyos"
         vm_password: "vyos"
         copy:
-            src: "/tmp/vyos_rolling_release.conf"
+            src: "/tmp/vyos.conf"
             dest: "/config/config.boot"
             overwrite: true
       when: 


### PR DESCRIPTION
Also included a task to delete the CustomISO image from the datastore after the hosts are built.   Also added "Pod-###-" to NSX Manager's hostname for consistency and to prepare for full "multi-pod" deployment support.