### PR TITLE
DNS Configuration FIle

### DIFF
--- a/answerfile_LargeEdge.yml
+++ b/answerfile_LargeEdge.yml
@@ -247,7 +247,7 @@ vESX:
   ESXi-21:
     ip:                      "{{ pod_network }}.{{ pod + management }}.21"
     mask:                    "{{ mgmt_network_mask }}"
-    gw:                      "{{ pod_network }}.{{ pod + management }}.2"
+    gw:                      "{{ pod_network }}.{{ pod + management }}.1"
     fqdn:                    "{{ pod_network }}.{{ pod + management }}.21"
     vmname:                  "Pod-{{ '%03d'|format(pod) }}-ESXi-21"
     cluster:                 "Compute-A"                                  # The cluster in the nested vSphere environment this ESXi will be added to.
@@ -269,7 +269,7 @@ vESX:
   ESXi-22:
     ip:                      "{{ pod_network }}.{{ pod + management }}.22"
     mask:                    "{{ mgmt_network_mask }}"
-    gw:                      "{{ pod_network }}.{{ pod + management }}.2"
+    gw:                      "{{ pod_network }}.{{ pod + management }}.1"
     fqdn:                    "{{ pod_network }}.{{ pod + management }}.22"
     vmname:                  "Pod-{{ '%03d'|format(pod) }}-ESXi-22"
     cluster:                 "Compute-A"                            # The cluster in the nested vSphere environment this ESXi will be added to.
@@ -291,7 +291,7 @@ vESX:
   ESXi-23:
     ip:                      "{{ pod_network }}.{{ pod + management }}.23"
     mask:                    "{{ mgmt_network_mask }}"
-    gw:                      "{{ pod_network }}.{{ pod + management }}.2"
+    gw:                      "{{ pod_network }}.{{ pod + management }}.1"
     fqdn:                    "{{ pod_network }}.{{ pod + management }}.23"
     vmname:                  "Pod-{{ '%03d'|format(pod) }}-ESXi-23"
     cluster:                 "Compute-A"                                  # The cluster in the nested vSphere environment this ESXi will be added to.

--- a/config_sample.yml
+++ b/config_sample.yml
@@ -71,8 +71,8 @@ Common:
   DNS:
     Domain: "lab.local"
     Server1:
-      IPv4: "{{ DNSServer.IPv4.Address }}"
-      IPv6: "{{ DNSServer.IPv6.Address }}"
+      IPv4: "{{ LabDNSServer.IPv4.Address }}"                     # If not using dedicated Lab DNS Server, change to DNS server you are using
+      IPv6: "{{ LabDNSServer.IPv6.Address }}"                     # If not using dedicated Lab DNS Server, change to DNS server you are using
     Server2:
       IPv4: 
       IPv6: 
@@ -298,7 +298,7 @@ Net:
 ##
 ## Dedicated Lab DNS Server
 ##
-DNSServer:
+LabDNSServer:
   Domain:    "{{ Common.DNS.Domain }}"
   UseDDNS:   true
   PortGroup: "{{ Nested_Router.Interface.Uplink.PortGroup }}"

--- a/config_sample.yml
+++ b/config_sample.yml
@@ -23,8 +23,10 @@ Deploy:
   IPv4: true
   IPv6: false
   UseNFS: false
-  UseDNS: false
+  UseDNS: false                              # Determines weather deployed components should use DNS to resolve names.  If set to false, then IP is used.
   EnableSSH: true
+  DNSServer:
+    UseDDNS: true                            # Use Dynamic DNS (DDNS) to update DNS Server A and PTR records on DNS server
   Software:
     Options:
       UseLocalInstaller: true
@@ -69,10 +71,10 @@ Common:
   DNS:
     Domain: "lab.local"
     Server1:
-      IPv4: "10.203.100.254"
-      IPv6: 
+      IPv4: "{{ DNSServer.IPv4.Address }}"
+      IPv6: "{{ DNSServer.IPv6.Address }}"
     Server2:
-      IPv4: "10.203.100.253"
+      IPv4: 
       IPv6: 
   NTP:
     Server1:
@@ -291,6 +293,22 @@ Net:
     IPv6:
       Prefix: 64
       Network: "{{ Pod.BaseNetwork.IPv6 }}:{{ '%04d'|format(Pod.Number+9|int) }}"
+
+
+##
+## Dedicated Lab DNS Server
+##
+DNSServer:
+  Domain:    "{{ Common.DNS.Domain }}"
+  UseDDNS:   true
+  PortGroup: "{{ Nested_Router.Interface.Uplink.PortGroup }}"
+  IPv4:
+    Address: "{{ (Nested_Router.Interface.Uplink.IPv4.Address + '/' + Nested_Router.Interface.Uplink.IPv4.Prefix) | ipaddr('network/prefix') | ipmath(5) }}"
+    Prefix:  "{{ Nested_Router.Interface.Uplink.IPv4.Prefix }}"
+    Gateway: "{{ Nested_Router.Interface.Uplink.IPv4.Gateway }}"
+  IPv6:
+    Address: "{{ (Nested_Router.Interface.Uplink.IPv6.Address + '/' + Nested_Router.Interface.Uplink.IPv6.Prefix) | ipaddr('network/prefix') | ipmath(5) }}"
+    Prefix:  "{{ Nested_Router.Interface.Uplink.IPv6.Prefix }}"
 
 
 Nested_Router:

--- a/playbooks/updateDNS.yml
+++ b/playbooks/updateDNS.yml
@@ -1,0 +1,149 @@
+###     Module Owner: Luis
+##
+##  Desired Enhancements:
+## 
+##
+---
+- hosts: localhost
+  name: updateDNS.yml
+  gather_facts: false
+  vars_files:
+    - ../config.yml
+    - ../software.yml
+  tasks:
+    - name: DEBUG -- Display Target Variables (Pause)
+      pause:
+        seconds: "{{ DEBUG.DisplayDelayInSeconds }}"
+        prompt: |
+          ================================ Display Variables For Pod {{ '%03d'|format(Pod.Number|int) }} ==================================
+
+                                     Ansible Playbook: {{ ansible_play_name }}
+
+                                    Target.Deployment: {{ Target.Deployment }}
+
+                                        Deploy.UseDNS: {{ Deploy.UseDNS }}
+
+                                     DNSServer.Domain: {{ DNSServer.Domain }}
+                                    DNSServer.UseDDNS: {{ DNSServer.UseDDNS }}
+                               DNSServer.IPv4.Address: {{ DNSServer.IPv4.Address }}
+                               DNSServer.IPv6.Address: {{ DNSServer.IPv6.Address }}
+
+
+          =================================================================================================
+      when:
+        - DEBUG.DisplayVariables == true
+
+
+##
+## Begin adding records to DNS Server
+##
+    - name: Create a VMware vSphere Standard Switch (vSS) on the ESXi host
+      vmware_vswitch:
+        hostname: "{{ Target.FQDN }}"
+        username: "{{ Target.User }}"
+        password: "{{ Target.Password }}"
+        validate_certs: false
+        esxi_hostname: "{{ Target.FQDN }}"
+        switch_name: "{{ Target.vSwitch }}"
+        mtu: 9000
+      when:
+        - Target.Deployment == "Host"
+
+    - name: Create a management port group for the lab environment
+      vmware_portgroup:
+        hostname: "{{ Target.FQDN }}"
+        username: "{{ Target.User }}"
+        password: "{{ Target.Password }}"
+        validate_certs: false        
+        esxi_hostname: "{{ Target.FQDN }}"
+        switch_name: "{{ Target.vSwitch }}"
+        portgroup_name: "{{ Target.PortGroup.Management.Name }}"
+        vlan_id: "{{ Target.PortGroup.Management.VLAN }}"
+        security:
+          promiscuous_mode: True
+      when:
+        - Target.Deployment == "Host"
+
+    - name: Create trunk port group for the lab environment
+      vmware_portgroup:
+        hostname: "{{ Target.FQDN }}"
+        username: "{{ Target.User }}"
+        password: "{{ Target.Password }}"
+        validate_certs: false
+        esxi_hostname: "{{ Target.FQDN }}"
+        switch_name: "{{ Target.vSwitch }}"
+        portgroup_name: "{{ Target.PortGroup.Trunk.Name }}"
+        vlan_id: "{{ Target.PortGroup.Trunk.VLAN }}"
+        security:
+          promiscuous_mode: True
+          forged_transmits: True
+          mac_changes: True
+      when:
+        - Target.Deployment == "Host"
+          
+
+##
+## Create vSphere Disributed Switch
+##
+    - name: Create a VMware vSphere Distributed Switch (vDS) in vCenter
+      vmware_dvswitch:
+        hostname: "{{ Target.FQDN }}"
+        username: "{{ Target.User }}"
+        password: "{{ Target.Password }}"
+        datacenter_name: "{{ Target.DataCenter }}"
+        validate_certs: false
+        description: "Pod-{{ Pod.Number }} vDS"
+        switch_name: "{{ Target.vSwitch }}"
+        discovery_operation: both
+        discovery_proto: lldp
+        switch_version: "{{ Target.vSwitchVersion }}"
+        uplink_prefix: "Pod-{{ Pod.Number }}-Uplink"
+        uplink_quantity: 1
+        state: present
+        mtu: 9000
+      when:
+        - Target.Deployment == "vCenter"
+
+    - name: Create a Management Distributed Port-Group in vCenter
+      vmware_dvs_portgroup:
+        hostname: "{{ Target.FQDN }}"
+        username: "{{ Target.User }}"
+        password: "{{ Target.Password }}"
+        validate_certs: false
+        switch_name: "{{ Target.vSwitch }}"
+        portgroup_type: lateBinding                                  # *TBD*-Need to verify lateBinding is appropriate
+        portgroup_name: "{{ Target.PortGroup.Management.Name }}"
+        vlan_id: "{{ Target.PortGroup.Management.VLAN }}"
+        vlan_trunk: false
+        num_ports: 32
+        state: present
+        network_policy:
+          promiscuous: True
+      when:
+        - Target.Deployment == "vCenter"
+
+    - name: Create a Trunk Distributed Port-Group in vCenter
+      vmware_dvs_portgroup:
+        hostname: "{{ Target.FQDN }}"
+        username: "{{ Target.User }}"
+        password: "{{ Target.Password }}"
+        validate_certs: false
+        switch_name: "{{ Target.vSwitch }}"
+        portgroup_type: lateBinding                                  # *TBD*-Need to verify lateBinding is appropriate
+        portgroup_name: "{{ Target.PortGroup.Trunk.Name }}"
+        vlan_id: "{{ Target.PortGroup.Trunk.VLAN }}"
+        vlan_trunk: true
+        num_ports: 32
+        state: present
+        network_policy:
+          promiscuous: True
+          forged_transmits: True
+          mac_changes: True
+      when:
+        - Target.Deployment == "vCenter"
+
+
+
+    - name: Wait 5 seconds for the port groups to become available
+      pause: seconds=5
+

--- a/playbooks/updateDNS.yml
+++ b/playbooks/updateDNS.yml
@@ -23,7 +23,7 @@
 
                                         Deploy.UseDNS: {{ Deploy.UseDNS }}
 
-                                     DNSServer.Domain: {{ DNSServer.Domain }}
+                                    Common.DNS.Domain: {{ Common.DNS.Domain }}
                                     DNSServer.UseDDNS: {{ DNSServer.UseDDNS }}
                                DNSServer.IPv4.Address: {{ DNSServer.IPv4.Address }}
                                DNSServer.IPv6.Address: {{ DNSServer.IPv6.Address }}

--- a/utils/DNS_Configuration_Information.txt
+++ b/utils/DNS_Configuration_Information.txt
@@ -1,0 +1,215 @@
+Useful Blog:
+     https://www.linuxbabe.com/ubuntu/set-up-local-dns-resolver-ubuntu-20-04-bind9
+
+
+Install Ubuntu Server 20.04 with static IP address
+
+Install BIND using this command:
+     sudo apt update
+     sudo apt install bind9 bind9utils bind9-doc host9-host
+
+Other miscellaneous useful tools to install:
+     sudo apt install net-tools
+
+NOTE: By design, the local DNS server is NOT updated to point to itself for DNS when done.
+      This is just to ensure it can still resolve names should a repair be required.
+
+================================= NEXT FILE ============================================
+
+
+//
+// File: /etc/bind/named.conf.options
+//
+
+// caching only DNS server config
+//
+acl lab-networks {
+  10.203.0.0/16;
+  10.0.0.0/8;
+  localhost;
+  localnets;
+};
+
+options {
+  directory "/var/cache/bind";
+  recursion yes;
+  allow-query { any; };
+  allow-query-cache { any; };
+  allow-recursion { lab-networks; };
+  forwarders { 
+    10.200.64.254;         // Update to 4.2.2.2
+    10.100.64.254;         // Update to 8.8.8.8
+  }; 
+  dnssec-validation no;
+  auth-nxdomain no; # conform to RFC1035
+  listen-on { localhost; any; };
+  listen-on-v6 { localhost; any; };
+  allow-transfer { none; };
+};
+
+
+================================= NEXT FILE ============================================
+
+//
+// File: /etc/bind/named.conf.local
+//
+
+//
+// Do any local configuration here
+//
+
+// Consider adding the 1918 zones here, if they are not used in your
+// organization
+//include "/etc/bind/zones.rfc1918";
+
+zone "lab.local" {
+  type master;
+  allow-update {10.203.0.0/16;};
+  file "/etc/bind/db.lab.local";
+};
+
+zone "203.10.in-addr.arpa." {
+  type master;
+  allow-update {10.203.0.0/16;};
+  file "/etc/bind/db.10.203";
+};
+
+
+================================= NEXT FILE ============================================
+
+
+;;
+;; File: /etc/bind/db.lab.local
+;;
+
+$TTL 604800
+@ IN SOA dns.lab.local. admin.lab.local. (
+          10   ; Serial
+      604800   ; Refresh
+       86400   ; Retry
+     2419200   ; Expire
+      604800 ) ; Negative Cache TTL
+;
+
+; Name servers
+lab.local.    IN   NS   dns.lab.local.
+
+; Define Origin
+$ORIGIN lab.local.
+
+; A records for name servers
+dns            IN   A    10.203.0.5
+
+; Other A records
+
+
+
+
+
+
+================================= NEXT FILE ============================================
+
+
+
+;;
+;; File: /etc/bind/db.10.203
+;;
+
+$TTL 604800
+@ IN SOA dns.lab.local. admin.lab.local. (
+          10   ; Serial
+      604800   ; Refresh
+       86400   ; Retry
+     2419200   ; Expire
+      604800 ) ; Negative Cache TTL
+;
+
+; Name servers
+203.10.in-addr.arpa.    IN   NS   dns.lab.local.
+
+; A records for name servers
+dns            IN   A    10.203.0.5
+
+;Define origin
+$ORIGIN 203.10.in-addr.arpa.
+
+; PTR records
+5.0    IN   PTR  dns.lab.local.
+
+
+================================= NEXT FILE ============================================
+
+
+Useful Commands:
+================
+
+     Start BIND:
+          sudo systemctl start named
+
+     Restart BIND:
+          sudo systemctl restart named
+
+     BIND Status (Useful to show errors in configuraton)
+          sudo systemctl status named
+
+     Enable auto-start at enable BIND:
+          sudo systemctl enable named
+
+     Verify all listeners are operational:
+          sudo netstat -lnptu | grep named
+
+     Check status of BIND server:
+          sudo rndc status
+
+     Verify zone files via:
+          named-checkconf /etc/bind/named.conf
+          echo $?
+
+     Verify BIND is working (from DNS server)
+          From BIND Server:  dig @127.0.0.1 dns.lab.local
+          From other systems: dig @<IP-OF-BIND-SeRVER> dns.lab.local
+
+
+
+
+
+Expected Output From Working System
+====================================
+adminuser@lab-dns:/etc/bind$ 
+adminuser@lab-dns:/etc/bind$ 
+adminuser@lab-dns:/etc/bind$ sudo netstat -lnptu | grep named
+tcp        0      0 10.203.0.5:53           0.0.0.0:*               LISTEN      7994/named          
+tcp        0      0 127.0.0.1:53            0.0.0.0:*               LISTEN      7994/named          
+tcp        0      0 127.0.0.1:953           0.0.0.0:*               LISTEN      7994/named          
+tcp6       0      0 fe80::20c:29ff:fe17::53 :::*                    LISTEN      7994/named          
+tcp6       0      0 ::1:53                  :::*                    LISTEN      7994/named          
+tcp6       0      0 ::1:953                 :::*                    LISTEN      7994/named          
+udp        0      0 10.203.0.5:53           0.0.0.0:*                           7994/named          
+udp        0      0 127.0.0.1:53            0.0.0.0:*                           7994/named          
+udp6       0      0 ::1:53                  :::*                                7994/named          
+udp6       0      0 fe80::20c:29ff:fe17::53 :::*                                7994/named          
+adminuser@lab-dns:/etc/bind$ 
+adminuser@lab-dns:/etc/bind$ 
+adminuser@lab-dns:/etc/bind$ 
+adminuser@lab-dns:/etc/bind$ sudo systemctl restart named
+adminuser@lab-dns:/etc/bind$ sudo systemctl status named 
+● named.service - BIND Domain Name Server
+     Loaded: loaded (/lib/systemd/system/named.service; enabled; vendor preset: enabled)
+     Active: active (running) since Sun 2020-06-21 23:30:19 UTC; 1s ago
+       Docs: man:named(8)
+   Main PID: 7994 (named)
+      Tasks: 5 (limit: 1075)
+     Memory: 11.6M
+     CGroup: /system.slice/named.service
+             └─7994 /usr/sbin/named -f -u bind
+
+Jun 21 23:30:19 lab-dns named[7994]: command channel listening on ::1#953
+Jun 21 23:30:19 lab-dns named[7994]: managed-keys-zone: loaded serial 3
+Jun 21 23:30:19 lab-dns named[7994]: zone 0.in-addr.arpa/IN: loaded serial 1
+Jun 21 23:30:19 lab-dns named[7994]: zone 203.10.in-addr.arpa/IN: loaded serial 10
+Jun 21 23:30:19 lab-dns named[7994]: zone 127.in-addr.arpa/IN: loaded serial 1
+Jun 21 23:30:19 lab-dns named[7994]: zone lab.local/IN: loaded serial 10
+Jun 21 23:30:19 lab-dns named[7994]: zone 255.in-addr.arpa/IN: loaded serial 1
+Jun 21 23:30:19 lab-dns named[7994]: zone localhost/IN: loaded serial 2
+Jun 21 23:30:19 lab-dns named[7994]: all zones loaded
+Jun 21 23:30:19 lab-dns named[7994]: running


### PR DESCRIPTION
Documented BIND server configuration, including validation steps and commands.  Placed the documented file in the Utils folder (for now).  This should be able to be used to automate the deployment of BIND server once it initial installation is complete.

Corrected Default Gateway IP from .2 to .1 in sample v1 configuration file.