### PR TITLE
Changes include: updateDNS, cleanupDNS, config_sample.yml, router

### DIFF
--- a/config_sample.yml
+++ b/config_sample.yml
@@ -394,7 +394,7 @@ Nested_Router:
       IPv4:
         Address: "pool.ntp.org"                   # If you do not permit NTP out to the Internet, please update this entry to point to your internal NTP server
       IPv6:
-        Address:
+        Address: "pool.ntp.org"                   # If you do not permit NTP out to the Internet, please update this entry to point to your internal NTP server
   OSPF:
     Area: 666
     RouterID: "{{ Pod.BaseNetwork.IPv4 }}.0.{{ Pod.Number }}"

--- a/config_sample.yml
+++ b/config_sample.yml
@@ -60,7 +60,9 @@ Deploy:
 
 
 ##
-## Users should change entries in the 'Common' section to match their environment
+## The 'Common' section are settings used by the various nested lab components, except for the Nested_Router.
+## The physical real-world NTP time server that is used to obtain time for the lab is defined in the Nested_Router section.
+## The DNS servers listed delow MUST be able to resolve DNS names on the public Internet.
 ##
 Common:
   Password:
@@ -76,11 +78,11 @@ Common:
       IPv6: 
   NTP:
     Server1:
-      IPv4: "10.200.0.10"                                             # Replace with your NTP Server IPv4 address
-      IPv6: "{{ Net.Management.IPv6.Network }}::1"                    # Replace with your NTP Server IPv6 address
+      IPv4: "{{ Net.Management.IPv4.Network }}.1"                     # Replace with your IP address if Nested_Router.Version == "Legacy"
+      IPv6: "{{ Net.Management.IPv6.Network }}::1"                    # Replace with your IP address if Nested_Router.Version == "Legacy"
     Server2:
-      IPv4: "{{ Net.Management.IPv4.Network }}.1"                     # Replace with your NTP Server IPv4 address
-      IPv6: "{{ Net.Management.IPv6.Network }}::1"                    # Replace with your NTP Server IPv6 address
+      IPv4: "{{ Net.Management.IPv4.Network }}.1"                     # Replace with your IP address if Nested_Router.Version == "Legacy"
+      IPv6: "{{ Net.Management.IPv6.Network }}::1"                    # Replace with your IP address if Nested_Router.Version == "Legacy"
   Syslog:
     IPv4: "10.203.100.26"
     IPv6: 
@@ -386,6 +388,13 @@ Nested_Router:
       IPv6:
         Address: "{{ Net.VMNetwork.IPv6.Network }}::1"
         Prefix:  "{{ Net.VMNetwork.IPv6.Prefix }}"
+  NTP:
+    Servers:
+    - Name: Upstream NTP Server
+      IPv4:
+        Address: "pool.ntp.org"                   # If you do not permit NTP out to the Internet, please update this entry to point to your internal NTP server
+      IPv6:
+        Address:
   OSPF:
     Area: 666
     RouterID: "{{ Pod.BaseNetwork.IPv4 }}.0.{{ Pod.Number }}"

--- a/deploy.yml
+++ b/deploy.yml
@@ -2,6 +2,9 @@
 # Writing Pod documentation
 - import_playbook: playbooks/writePodDoc.yml
 
+# Populate DNS with forward and reverse DNS records
+- import_playbook: playbooks/updateDNS.yml
+
 # Nested vSphere deployment starts here
 - import_playbook: playbooks/preparePhysical.yml
 - import_playbook: playbooks/deployRouter.yml

--- a/playbooks/cleanupDNS.yml
+++ b/playbooks/cleanupDNS.yml
@@ -1,0 +1,631 @@
+## Luis has ownership of this file for the v2 migration ##
+#
+#
+---
+- hosts: localhost
+  name: cleanupDNS.yml
+  gather_facts: false
+  vars:
+    - LOCAL_RecordState: "absent"            # LOCAL_RecordState values are either "present" (Records will be added) or "absent" (Records will be deleted)
+  vars_files:
+    - ../software.yml
+    - ../config.yml
+  tasks:
+    - name: DEBUG -- Display Target Variables (Pause)
+      pause:
+        seconds: "{{ DEBUG.DisplayDelayInSeconds }}"
+        prompt: |
+          ================================ Display Variables For Pod {{ '%03d'|format(Pod.Number|int) }} ==================================
+
+                                     Ansible Playbook: {{ ansible_play_name }}
+
+                                    Target.Deployment: {{ Target.Deployment }}
+
+                                        Deploy.UseDNS: {{ Deploy.UseDNS }}
+                                    LOCAL_RecordState: {{ LOCAL_RecordState }}
+                                    Common.DNS.Domain: {{ Common.DNS.Domain }}
+                              Common.DNS.Server1.IPv4: {{ Common.DNS.Server1.IPv4 }}
+                              Common.DNS.Server1.IPv6: {{ Common.DNS.Server1.IPv6 }}
+
+                                 Pod.BaseNetwork.IPv4: {{ Pod.BaseNetwork.IPv4 }} 
+                                 Pod.BaseNetwork.IPv6: {{ Pod.BaseNetwork.IPv6 }} 
+
+          =================================================================================================
+      when:
+        - DEBUG.DisplayVariables == true
+
+
+##
+## Remove Nested_Router
+##
+    - name: DEBUG -- Display IPv4 'A' records for Nested_Router
+      pause:
+        seconds: 1
+        prompt: |
+          ========================== Display Nested_Router DNS "A" Records ================================
+
+                                        Deploy.UseDNS: {{ Deploy.UseDNS }}
+                                    LOCAL_RecordState: {{ LOCAL_RecordState }}
+
+                                           DNS Server: {{ Common.DNS.Server1.IPv4 }}
+                                                 Zone: {{ Common.DNS.Domain }}
+                                               Record: {{ Nested_Router.Name }}-{{ item.key }}
+                                                Value: {{ item.value.IPv4.Address }}
+
+          =================================================================================================
+      loop: "{{ Nested_Router.Interface | dict2items }}"
+      when:
+        - DEBUG.DisplayVariables == true
+        - Deploy.UseDNS == true
+        - Deploy.IPv4 == true
+
+    - name: Delete IPv4 'A' records for Nested_Router
+      nsupdate:
+        server:   "{{ Common.DNS.Server1.IPv4 }}"
+        type:     "A"
+        protocol: "udp"
+        zone:     "{{ Common.DNS.Domain }}"
+        record:   "{{ Nested_Router.Name }}-{{ item.key }}"
+        value:    "{{ item.value.IPv4.Address }}"
+        state:    "{{ LOCAL_RecordState }}"
+      loop: "{{ Nested_Router.Interface | dict2items }}"
+      when:
+        - Deploy.UseDNS == true
+        - Deploy.IPv4 == true
+
+
+
+    - name: DEBUG -- Display IPv4 'PTR' records for Nested_Router
+      pause:
+        seconds: 1
+        prompt: |
+          ========================== Display Nested_Router DNS IPv4 "PTR" Records =========================
+
+                                        Deploy.UseDNS: {{ Deploy.UseDNS }}
+                                    LOCAL_RecordState: {{ LOCAL_RecordState }}
+
+                                           DNS Server: {{ Common.DNS.Server1.IPv4 }}
+                                                 Zone: {{ Common.DNS.Domain }}
+                                               Record: {{ item.value.IPv4.Address | ipaddr('revdns') }}
+                                                Value: {{ Nested_Router.Name }}-{{ item.key }}.{{ Common.DNS.Domain }}
+
+          =================================================================================================
+      loop: "{{ Nested_Router.Interface | dict2items }}"
+      when:
+        - DEBUG.DisplayVariables == true
+        - Deploy.UseDNS == true
+        - Deploy.IPv4 == true
+
+    - name: Delete IPv4 'PTR' records for Nested_Router
+      nsupdate:
+        server:   "{{ Common.DNS.Server1.IPv4 }}"
+        type:     "PTR"
+        protocol: "udp"
+        record:   "{{ item.value.IPv4.Address | ipaddr('revdns') }}"
+        value:    "{{ Nested_Router.Name }}-{{ item.key }}.{{ Common.DNS.Domain }}."
+        state:    "{{ LOCAL_RecordState }}"
+      loop: "{{ Nested_Router.Interface | dict2items }}"
+      when:
+        - Deploy.UseDNS == true
+        - Deploy.IPv4 == true
+
+
+
+    - name: DEBUG -- Display IPv6 'AAAA' records for Nested_Router
+      pause:
+        seconds: 1
+        prompt: |
+          ========================== Display Nested_Router DNS IPv6 "AAAA" Records ========================
+
+                                        Deploy.UseDNS: {{ Deploy.UseDNS }}
+                                    LOCAL_RecordState: {{ LOCAL_RecordState }}
+
+                                           DNS Server: {{ Common.DNS.Server1.IPv6 }}
+                                                 Zone: {{ Common.DNS.Domain }}
+                                               Record: {{ item.value.IPv6.Address }}
+                                                Value: {{ Nested_Router.Name }}-{{ item.key }}.{{ Common.DNS.Domain }}
+
+          =================================================================================================
+      loop: "{{ Nested_Router.Interface | dict2items }}"
+      when:
+        - DEBUG.DisplayVariables == true
+        - Deploy.UseDNS == true
+        - Deploy.IPv6 == true
+
+    - name: Delete IPv6 'AAAA' records for Nested_Router
+      nsupdate:
+        server:   "{{ Common.DNS.Server1.IPv6 }}"
+        type:     "AAAA"
+        protocol: "udp"
+        zone:     "{{ Common.DNS.Domain }}"
+        record:   "{{ Nested_Router.Name }}-{{ item.key }}"
+        value:    "{{ item.value.IPv6.Address }}"
+        state:    "{{ LOCAL_RecordState }}"
+      loop: "{{ Nested_Router.Interface | dict2items }}"
+      when:
+        - Deploy.UseDNS == true
+        - Deploy.IPv6 == true
+
+
+
+
+    - name: DEBUG -- Display IPv6 'PTR' records for Nested_Router
+      pause:
+        seconds: 1
+        prompt: |
+          ========================== Display Nested_Router DNS IPv6 "PTR" Records =========================
+
+                                        Deploy.UseDNS: {{ Deploy.UseDNS }}
+                                    LOCAL_RecordState: {{ LOCAL_RecordState }}
+
+                                           DNS Server: {{ Common.DNS.Server1.IPv6 }}
+                                                 Zone: {{ Common.DNS.Domain }}
+                                               Record: {{ item.value.IPv6.Address | ipaddr('revdns') }}
+                                                Value: {{ Nested_Router.Name }}-{{ item.key }}.{{ Common.DNS.Domain }}
+
+          =================================================================================================
+      loop: "{{ Nested_Router.Interface | dict2items }}"
+      when:
+        - DEBUG.DisplayVariables == true
+        - Deploy.UseDNS == true
+        - Deploy.IPv6 == true
+
+    - name: Delete IPv6 'PTR' records for Nested_Router
+      nsupdate:
+        server:   "{{ Common.DNS.Server1.IPv4 }}"
+        type:     "PTR"
+        protocol: "udp"
+        record:   "{{ item.value.IPv6.Address | ipaddr('revdns') }}"
+        value:    "{{ Nested_Router.Name }}-{{ item.key }}.{{ Common.DNS.Domain }}."
+        state:    "{{ LOCAL_RecordState }}"
+      loop: "{{ Nested_Router.Interface | dict2items }}"
+      when:
+        - Deploy.UseDNS == true
+        - Deploy.IPv6 == true
+
+
+
+
+
+
+
+##
+## Remove Nested_ESXi Hosts
+##
+    - name: DEBUG -- Display IPv4 'A' records for Nested_ESXi hosts
+      pause:
+        seconds: 1
+        prompt: |
+          =========================== Display Nested_ESXi DNS "A" Records =================================
+
+                                        Deploy.UseDNS: {{ Deploy.UseDNS }}
+                                    LOCAL_RecordState: {{ LOCAL_RecordState }}
+
+                                           DNS Server: {{ Common.DNS.Server1.IPv4 }}
+                                                 Zone: {{ Common.DNS.Domain }}
+                                               Record: {{ item.value.VMName }}
+                                                Value: {{ item.value.vmk.vmk0.Address.IPv4.Address }}
+
+          =================================================================================================
+      loop: "{{ Nested_ESXi.Hosts | dict2items }}"
+      when:
+        - DEBUG.DisplayVariables == true
+        - Deploy.UseDNS == true
+        - Deploy.IPv4 == true
+
+
+    - name: Delete IPv4 'A' records for Nested_ESXi hosts
+      nsupdate:
+        server:   "{{ Common.DNS.Server1.IPv4 }}"
+        type:     "A"
+        protocol: "udp"
+        zone:     "{{ Common.DNS.Domain }}"
+        record:   "{{ item.value.VMName }}"
+        value:    "{{ item.value.vmk.vmk0.Address.IPv4.Address }}"
+        state:    "{{ LOCAL_RecordState }}"
+      loop: "{{ Nested_ESXi.Hosts | dict2items }}"
+      when: 
+        - Deploy.UseDNS == true
+        - Deploy.IPv4 == true
+
+
+
+    - name: DEBUG -- Display IPv4 'PTR' records for Nested_ESXi Hosts
+      pause:
+        seconds: 1
+        prompt: |
+          ========================== Display Nested_ESXi DNS IPv4 "PTR" Records ===========================
+
+                                        Deploy.UseDNS: {{ Deploy.UseDNS }}
+                                    LOCAL_RecordState: {{ LOCAL_RecordState }}
+
+                                           DNS Server: {{ Common.DNS.Server1.IPv4 }}
+                                                 Zone: {{ Common.DNS.Domain }}
+                                               Record: {{ item.value.vmk.vmk0.Address.IPv4.Address | ipaddr('revdns') }}
+                                                Value: {{ item.value.VMName }}.{{ Common.DNS.Domain }}.
+
+          =================================================================================================
+      loop: "{{ Nested_ESXi.Hosts | dict2items }}"
+      when:
+        - DEBUG.DisplayVariables == true
+        - Deploy.UseDNS == true
+        - Deploy.IPv4 == true
+
+
+    - name: Delete IPv4 'PTR' records for Nested_ESXi hosts
+      nsupdate:
+        server:   "{{ Common.DNS.Server1.IPv4 }}"
+        type:     "PTR"
+        protocol: "udp"
+        record:   "{{ item.value.vmk.vmk0.Address.IPv4.Address | ipaddr('revdns') }}"
+        value:    "{{ item.value.VMName }}.{{ Common.DNS.Domain }}."
+        state:    "{{ LOCAL_RecordState }}"
+      loop: "{{ Nested_ESXi.Hosts | dict2items }}"
+      when: 
+        - Deploy.UseDNS == true
+        - Deploy.IPv4 == true
+
+
+
+    - name: DEBUG -- Display IPv6 'AAAA' records for Nested_ESXi hosts
+      pause:
+        seconds: 1
+        prompt: |
+          =========================== Display Nested_ESXi DNS "AAAA" Records ==============================
+
+                                        Deploy.UseDNS: {{ Deploy.UseDNS }}
+                                    LOCAL_RecordState: {{ LOCAL_RecordState }}
+
+                                           DNS Server: {{ Common.DNS.Server1.IPv6 }}
+                                                 Zone: {{ Common.DNS.Domain }}
+                                               Record: {{ item.value.VMName }}
+                                                Value: {{ item.value.vmk.vmk0.Address.IPv6.Address }}
+
+          =================================================================================================
+      loop: "{{ Nested_ESXi.Hosts | dict2items }}"
+      when:
+        - DEBUG.DisplayVariables == true
+        - Deploy.UseDNS == true
+        - Deploy.IPv6 == true
+
+    - name: Delete IPv6 'AAAA' records for Nested_ESXi hosts
+      nsupdate:
+        server:   "{{ Common.DNS.Server1.IPv6 }}"
+        type:     "AAAA"
+        protocol: "udp"
+        zone:     "{{ Common.DNS.Domain }}"
+        record:   "{{ item.value.VMName }}"
+        value:    "{{ item.value.vmk.vmk0.Address.IPv6.Address }}"
+        state:    "{{ LOCAL_RecordState }}"
+      loop: "{{ Nested_ESXi.Hosts | dict2items }}"
+      when: 
+        - Deploy.UseDNS == true
+        - Deploy.IPv6 == true
+
+
+
+
+    - name: DEBUG -- Display IPv6 'PTR' records for Nested_ESXi Hosts
+      pause:
+        seconds: 1
+        prompt: |
+          ========================== Display Nested_ESXi DNS IPv6 "PTR" Records ===========================
+
+                                        Deploy.UseDNS: {{ Deploy.UseDNS }}
+                                    LOCAL_RecordState: {{ LOCAL_RecordState }}
+
+                                           DNS Server: {{ Common.DNS.Server1.IPv6 }}
+                                                 Zone: {{ Common.DNS.Domain }}
+                                               Record: item.value.vmk.vmk0.Address.IPv6.Address | ipaddr('revdns') }}
+                                                Value: {{ item.value.VMName }}.{{ Common.DNS.Domain }}. 
+
+          =================================================================================================
+      loop: "{{ Nested_ESXi.Hosts | dict2items }}"
+      when:
+        - DEBUG.DisplayVariables == true
+        - Deploy.UseDNS == true
+        - Deploy.IPv6 == true
+
+    - name: Delete IPv6 'PTR' records for Nested_ESXi hosts
+      nsupdate:
+        server:   "{{ Common.DNS.Server1.IPv6 }}"
+        type:     "PTR"
+        protocol: "udp"
+        record:   "{{ item.value.vmk.vmk0.Address.IPv6.Address | ipaddr('revdns') }}"
+        value:    "{{ item.value.VMName }}.{{ Common.DNS.Domain }}."
+        state:    "{{ LOCAL_RecordState }}"
+      loop: "{{ Nested_ESXi.Hosts | dict2items }}"
+      when: 
+        - Deploy.UseDNS == true
+        - Deploy.IPv6 == true
+
+
+
+##
+## Remove Nested_vCenter
+##
+    - name: DEBUG -- Display IPv4 'A' record for Nested_vCenter
+      pause:
+        seconds: 1
+        prompt: |
+          ======================== Display Nested_vCenter DNS IPv4 "A" Record =============================
+
+                                        Deploy.UseDNS: {{ Deploy.UseDNS }}
+                                    LOCAL_RecordState: {{ LOCAL_RecordState }}
+
+                                           DNS Server: {{ Common.DNS.Server1.IPv4 }}
+                                                 Zone: {{ Common.DNS.Domain }}
+                                               Record: {{ Nested_vCenter.VMName }}
+                                                Value: {{ Nested_vCenter.Address.IPv4.Address }}
+
+          =================================================================================================
+      when:
+        - DEBUG.DisplayVariables == true
+        - Deploy.UseDNS == true
+        - Deploy.IPv4 == true
+
+    - name: Delete IPv4 'A' records for Nested_vCenter
+      nsupdate:
+        server:   "{{ Common.DNS.Server1.IPv4 }}"
+        type:     "A"
+        protocol: "udp"
+        zone:     "{{ Common.DNS.Domain }}"
+        record:   "{{ Nested_vCenter.VMName }}"
+        value:    "{{ Nested_vCenter.Address.IPv4.Address }}"
+        state:    "{{ LOCAL_RecordState }}"
+      when:
+        - Deploy.UseDNS == true
+        - Deploy.IPv4 == true
+
+
+
+
+    - name: DEBUG -- Display IPv4 'PTR' record for Nested_vCenter
+      pause:
+        seconds: 1
+        prompt: |
+          ======================== Display Nested_vCenter DNS IPv4 "PTR" Record ===========================
+
+                                        Deploy.UseDNS: {{ Deploy.UseDNS }}
+                                    LOCAL_RecordState: {{ LOCAL_RecordState }}
+
+                                           DNS Server: {{ Common.DNS.Server1.IPv4 }}
+                                               Record: {{ Nested_vCenter.Address.IPv4.Address | ipaddr('revdns') }}
+                                                Value: {{ Nested_vCenter.VMName }}.{{ Common.DNS.Domain }}.
+
+          =================================================================================================
+      when:
+        - DEBUG.DisplayVariables == true
+        - Deploy.UseDNS == true
+        - Deploy.IPv4 == true
+
+    - name: Delete IPv4 'PTR' records for Nested_vCenter
+      nsupdate:
+        server:   "{{ Common.DNS.Server1.IPv4 }}"
+        type:     "PTR"
+        protocol: "udp"
+        record:   "{{ Nested_vCenter.Address.IPv4.Address | ipaddr('revdns') }}"
+        value:    "{{ Nested_vCenter.VMName }}.{{ Common.DNS.Domain }}."
+        state:    "{{ LOCAL_RecordState }}"
+      when:
+        - Deploy.UseDNS == true
+        - Deploy.IPv4 == true
+
+
+
+
+    - name: DEBUG -- Display IPv6 'AAAA' record for Nested_vCenter
+      pause:
+        seconds: 1
+        prompt: |
+          ======================= Display Nested_vCenter DNS IPv6 "AAAA" Record ===========================
+
+                                        Deploy.UseDNS: {{ Deploy.UseDNS }}
+                                    LOCAL_RecordState: {{ LOCAL_RecordState }}
+
+                                           DNS Server: {{ Common.DNS.Server1.IPv6 }}
+                                                 Zone: {{ Common.DNS.Domain }}
+                                               Record: {{ Nested_vCenter.VMName }}
+                                                Value: {{ Nested_vCenter.Address.IPv6.Address }}
+
+          =================================================================================================
+      when:
+        - DEBUG.DisplayVariables == true
+        - Deploy.UseDNS == true
+        - Deploy.IPv6 == true
+
+    - name: Delete IPv6 'AAAA' records for Nested_vCenter
+      nsupdate:
+        server:   "{{ Common.DNS.Server1.IPv6 }}"
+        type:     "AAAA"
+        protocol: "udp"
+        zone:     "{{ Common.DNS.Domain }}"
+        record:   "{{ Nested_vCenter.VMName }}"
+        value:    "{{ Nested_vCenter.Address.IPv6.Address }}"
+        state:    "{{ LOCAL_RecordState }}"
+      when:
+        - Deploy.UseDNS == true
+        - Deploy.IPv6 == true
+
+
+
+
+
+    - name: DEBUG -- Display IPv6 'PTR' record for Nested_vCenter
+      pause:
+        seconds: 1
+        prompt: |
+          ======================== Display Nested_vCenter DNS IPv6 "PTR" Record ===========================
+
+                                        Deploy.UseDNS: {{ Deploy.UseDNS }}
+                                    LOCAL_RecordState: {{ LOCAL_RecordState }}
+
+                                           DNS Server: {{ Common.DNS.Server1.IPv6 }}
+                                               Record: {{ Nested_vCenter.Address.IPv6.Address | ipaddr('revdns') }}
+                                                Value: {{ Nested_vCenter.VMName }}.{{ Common.DNS.Domain }}.
+
+          =================================================================================================
+      when:
+        - DEBUG.DisplayVariables == true
+        - Deploy.UseDNS == true
+        - Deploy.IPv6 == true
+
+
+    - name: Delete IPv6 'PTR' records for Nested_vCenter
+      nsupdate:
+        server:   "{{ Common.DNS.Server1.IPv6 }}"
+        type:     "PTR"
+        protocol: "udp"
+        record:   "{{ Nested_vCenter.Address.IPv6.Address | ipaddr('revdns') }}"
+        value:    "{{ Nested_vCenter.VMName }}.{{ Common.DNS.Domain }}."
+        state:    "{{ LOCAL_RecordState }}"
+      when:
+        - Deploy.UseDNS == true
+        - Deploy.IPv6 == true
+
+
+##
+## Remove Nested_NSXT Components
+##
+    - name: DEBUG -- Display IPv4 'A' records for Nested_NSXT
+      pause:
+        seconds: 1
+        prompt: |
+          ============================ Display Nested_NSXT DNS "A" Records ================================
+
+                                        Deploy.UseDNS: {{ Deploy.UseDNS }}
+                                    LOCAL_RecordState: {{ LOCAL_RecordState }}
+
+                                           DNS Server: {{ Common.DNS.Server1.IPv4 }}
+                                                 Zone: {{ Common.DNS.Domain }}
+                                               Record: {{ item.value.VMName }}
+                                                Value: {{ item.value.Address.IPv4.Address }}
+
+          =================================================================================================
+      loop: "{{ Nested_NSXT.Components | dict2items }}"
+      when:
+        - DEBUG.DisplayVariables == true
+        - Deploy.UseDNS == true
+        - Deploy.IPv4 == true
+
+    - name: Delete IPv4 'A' records for Nested_NSXT Components
+      nsupdate:
+        server:   "{{ Common.DNS.Server1.IPv4 }}"
+        type:     "A"
+        protocol: "udp"
+        zone:     "{{ Common.DNS.Domain }}"
+        record:   "{{ item.value.VMName }}"
+        value:    "{{ item.value.Address.IPv4.Address }}"
+        state:    "{{ LOCAL_RecordState }}"
+      loop: "{{ Nested_NSXT.Components | dict2items }}"
+      when:
+        - Deploy.UseDNS == true
+        - Deploy.IPv4 == true
+
+
+
+    - name: DEBUG -- Display IPv4 'PTR' records for Nested_NSXT
+      pause:
+        seconds: 1
+        prompt: |
+          ========================== Display Nested_NSXT DNS IPv4 "PTR" Records ===========================
+
+                                        Deploy.UseDNS: {{ Deploy.UseDNS }}
+                                    LOCAL_RecordState: {{ LOCAL_RecordState }}
+
+                                           DNS Server: {{ Common.DNS.Server1.IPv4 }}
+                                               Record: {{ item.value.Address.IPv4.Address | ipaddr('revdns') }}
+                                                Value: {{ item.value.VMName }}.{{ Common.DNS.Domain }}.
+
+          =================================================================================================
+      loop: "{{ Nested_NSXT.Components | dict2items }}"
+      when:
+        - DEBUG.DisplayVariables == true
+        - Deploy.UseDNS == true
+        - Deploy.IPv4 == true
+
+    - name: Delete IPv4 'PTR' records for Nested_NSXT Components
+      nsupdate:
+        server:   "{{ Common.DNS.Server1.IPv4 }}"
+        type:     "PTR"
+        protocol: "udp"
+        record:   "{{ item.value.Address.IPv4.Address | ipaddr('revdns') }}"
+        value:    "{{ item.value.VMName }}.{{ Common.DNS.Domain }}."
+        state:    "{{ LOCAL_RecordState }}"
+      loop: "{{ Nested_NSXT.Components | dict2items }}"
+      when:
+        - Deploy.UseDNS == true
+        - Deploy.IPv4 == true
+
+
+
+    - name: DEBUG -- Display IPv6 'AAAA' records for Nested_NSXT
+      pause:
+        seconds: 1
+        prompt: |
+          ========================== Display Nested_NSXT DNS "AAAA" Records ===============================
+
+                                        Deploy.UseDNS: {{ Deploy.UseDNS }}
+                                    LOCAL_RecordState: {{ LOCAL_RecordState }}
+
+                                           DNS Server: {{ Common.DNS.Server1.IPv6 }}
+                                                 Zone: {{ Common.DNS.Domain }}
+                                               Record: {{ item.value.VMName }}
+                                                Value: {{ item.value.Address.IPv6.Address }}
+
+          =================================================================================================
+      loop: "{{ Nested_NSXT.Components | dict2items }}"
+      when:
+        - DEBUG.DisplayVariables == true
+        - Deploy.UseDNS == true
+        - Deploy.IPv6 == true
+
+    - name: Delete IPv6 'AAAA' records for Nested_NSXT Components
+      nsupdate:
+        server:   "{{ Common.DNS.Server1.IPv6 }}"
+        type:     "AAAA"
+        protocol: "udp"
+        zone:     "{{ Common.DNS.Domain }}"
+        record:   "{{ item.value.VMName }}"
+        value:    "{{ item.value.Address.IPv6.Address }}"
+        state:    "{{ LOCAL_RecordState }}"
+      loop: "{{ Nested_NSXT.Components | dict2items }}"
+      when:
+        - Deploy.UseDNS == true
+        - Deploy.IPv6 == true
+
+
+
+    - name: DEBUG -- Display IPv6 'PTR' records for Nested_NSXT
+      pause:
+        seconds: 1
+        prompt: |
+          ========================== Display Nested_NSXT DNS IPv6 "PTR" Records ===========================
+
+                                        Deploy.UseDNS: {{ Deploy.UseDNS }}
+                                    LOCAL_RecordState: {{ LOCAL_RecordState }}
+
+                                           DNS Server: {{ Common.DNS.Server1.IPv6 }}
+                                               Record: {{ item.value.Address.IPv6.Address | ipaddr('revdns') }}
+                                                Value: {{ item.value.VMName }}.{{ Common.DNS.Domain }}.
+
+          =================================================================================================
+      loop: "{{ Nested_NSXT.Components | dict2items }}"
+      when:
+        - DEBUG.DisplayVariables == true
+        - Deploy.UseDNS == true
+        - Deploy.IPv6 == true
+
+    - name: Delete IPv6 'PTR' records for Nested_NSXT Components
+      nsupdate:
+        server:   "{{ Common.DNS.Server1.IPv6 }}"
+        type:     "PTR"
+        protocol: "udp"
+        record:   "{{ item.value.Address.IPv6.Address | ipaddr('revdns') }}"
+        value:    "{{ item.value.VMName }}.{{ Common.DNS.Domain }}."
+        state:    "{{ LOCAL_RecordState }}"
+      loop: "{{ Nested_NSXT.Components | dict2items }}"
+      when:
+        - Deploy.UseDNS == true
+        - Deploy.IPv6 == true
+

--- a/playbooks/deployVc.yml
+++ b/playbooks/deployVc.yml
@@ -113,7 +113,9 @@
         cluster_name: "{{ item.key }}"
         validate_certs: False
       with_dict: "{{ Nested_Clusters }}"
-      when: vcenter_check.status != 200
+      when: 
+        - vcenter_check.status != 200
+        - item.value.DeployHosts == true
 
     - name: Enable DRS on each Cluster, if applicable
       vmware_cluster_drs:
@@ -125,4 +127,6 @@
         validate_certs: False
         enable_drs: "{{ item.value.DRS }}"
       with_dict: "{{ Nested_Clusters }}"
-      when: vcenter_check.status != 200
+      when: 
+        - vcenter_check.status != 200
+        - item.value.DeployHosts == true

--- a/playbooks/updateDNS.yml
+++ b/playbooks/updateDNS.yml
@@ -1,8 +1,14 @@
 ## Luis has ownership of this file for the v2 migration ##
+#
+# ToDo:
+#   1) Create IPv6 Reverse Zone
+#
 ---
 - hosts: localhost
   name: updateDNS.yml
   gather_facts: false
+  vars:
+    - LOCAL_RecordState: "present"           # LOCAL_RecordState values are either "present" (Records will be added) or "absent" (Records will be deleted)
   vars_files:
     - ../software.yml
     - ../config.yml
@@ -18,6 +24,7 @@
                                     Target.Deployment: {{ Target.Deployment }}
 
                                         Deploy.UseDNS: {{ Deploy.UseDNS }}
+                                    LOCAL_RecordState: {{ LOCAL_RecordState }}
                                     Common.DNS.Domain: {{ Common.DNS.Domain }}
                               Common.DNS.Server1.IPv4: {{ Common.DNS.Server1.IPv4 }}
                               Common.DNS.Server1.IPv6: {{ Common.DNS.Server1.IPv6 }}
@@ -33,6 +40,27 @@
 ##
 ## Add Nested_Router
 ##
+    - name: DEBUG -- Display IPv4 'A' records for Nested_Router
+      pause:
+        seconds: 1
+        prompt: |
+          ========================== Display Nested_Router DNS "A" Records ================================
+
+                                        Deploy.UseDNS: {{ Deploy.UseDNS }}
+                                    LOCAL_RecordState: {{ LOCAL_RecordState }}
+
+                                           DNS Server: {{ Common.DNS.Server1.IPv4 }}
+                                                 Zone: {{ Common.DNS.Domain }}
+                                               Record: {{ Nested_Router.Name }}-{{ item.key }}
+                                                Value: {{ item.value.IPv4.Address }}
+
+          =================================================================================================
+      loop: "{{ Nested_Router.Interface | dict2items }}"
+      when:
+        - DEBUG.DisplayVariables == true
+        - Deploy.UseDNS == true
+        - Deploy.IPv4 == true
+
     - name: Create IPv4 'A' records for Nested_Router
       nsupdate:
         server:   "{{ Common.DNS.Server1.IPv4 }}"
@@ -41,8 +69,32 @@
         zone:     "{{ Common.DNS.Domain }}"
         record:   "{{ Nested_Router.Name }}-{{ item.key }}"
         value:    "{{ item.value.IPv4.Address }}"
+        state:    "{{ LOCAL_RecordState }}"
       loop: "{{ Nested_Router.Interface | dict2items }}"
       when:
+        - Deploy.UseDNS == true
+        - Deploy.IPv4 == true
+
+
+
+    - name: DEBUG -- Display IPv4 'PTR' records for Nested_Router
+      pause:
+        seconds: 1
+        prompt: |
+          ========================== Display Nested_Router DNS IPv4 "PTR" Records =========================
+
+                                        Deploy.UseDNS: {{ Deploy.UseDNS }}
+                                    LOCAL_RecordState: {{ LOCAL_RecordState }}
+
+                                           DNS Server: {{ Common.DNS.Server1.IPv4 }}
+                                                 Zone: {{ Common.DNS.Domain }}
+                                               Record: {{ item.value.IPv4.Address | ipaddr('revdns') }}
+                                                Value: {{ Nested_Router.Name }}-{{ item.key }}.{{ Common.DNS.Domain }}
+
+          =================================================================================================
+      loop: "{{ Nested_Router.Interface | dict2items }}"
+      when:
+        - DEBUG.DisplayVariables == true
         - Deploy.UseDNS == true
         - Deploy.IPv4 == true
 
@@ -51,14 +103,36 @@
         server:   "{{ Common.DNS.Server1.IPv4 }}"
         type:     "PTR"
         protocol: "udp"
-        zone:     "203.10.in-addr.arpa"
         record:   "{{ item.value.IPv4.Address | ipaddr('revdns') }}"
         value:    "{{ Nested_Router.Name }}-{{ item.key }}.{{ Common.DNS.Domain }}."
+        state:    "{{ LOCAL_RecordState }}"
       loop: "{{ Nested_Router.Interface | dict2items }}"
       when:
         - Deploy.UseDNS == true
         - Deploy.IPv4 == true
 
+
+
+    - name: DEBUG -- Display IPv6 'AAAA' records for Nested_Router
+      pause:
+        seconds: 1
+        prompt: |
+          ========================== Display Nested_Router DNS IPv6 "AAAA" Records ========================
+
+                                        Deploy.UseDNS: {{ Deploy.UseDNS }}
+                                    LOCAL_RecordState: {{ LOCAL_RecordState }}
+
+                                           DNS Server: {{ Common.DNS.Server1.IPv6 }}
+                                                 Zone: {{ Common.DNS.Domain }}
+                                               Record: {{ item.value.IPv6.Address }}
+                                                Value: {{ Nested_Router.Name }}-{{ item.key }}.{{ Common.DNS.Domain }}
+
+          =================================================================================================
+      loop: "{{ Nested_Router.Interface | dict2items }}"
+      when:
+        - DEBUG.DisplayVariables == true
+        - Deploy.UseDNS == true
+        - Deploy.IPv6 == true
 
     - name: Create IPv6 'AAAA' records for Nested_Router
       nsupdate:
@@ -68,8 +142,33 @@
         zone:     "{{ Common.DNS.Domain }}"
         record:   "{{ Nested_Router.Name }}-{{ item.key }}"
         value:    "{{ item.value.IPv6.Address }}"
+        state:    "{{ LOCAL_RecordState }}"
       loop: "{{ Nested_Router.Interface | dict2items }}"
       when:
+        - Deploy.UseDNS == true
+        - Deploy.IPv6 == true
+
+
+
+
+    - name: DEBUG -- Display IPv6 'PTR' records for Nested_Router
+      pause:
+        seconds: 1
+        prompt: |
+          ========================== Display Nested_Router DNS IPv6 "PTR" Records =========================
+
+                                        Deploy.UseDNS: {{ Deploy.UseDNS }}
+                                    LOCAL_RecordState: {{ LOCAL_RecordState }}
+
+                                           DNS Server: {{ Common.DNS.Server1.IPv6 }}
+                                                 Zone: {{ Common.DNS.Domain }}
+                                               Record: {{ item.value.IPv6.Address | ipaddr('revdns') }}
+                                                Value: {{ Nested_Router.Name }}-{{ item.key }}.{{ Common.DNS.Domain }}
+
+          =================================================================================================
+      loop: "{{ Nested_Router.Interface | dict2items }}"
+      when:
+        - DEBUG.DisplayVariables == true
         - Deploy.UseDNS == true
         - Deploy.IPv6 == true
 
@@ -80,15 +179,43 @@
         protocol: "udp"
         record:   "{{ item.value.IPv6.Address | ipaddr('revdns') }}"
         value:    "{{ Nested_Router.Name }}-{{ item.key }}.{{ Common.DNS.Domain }}."
+        state:    "{{ LOCAL_RecordState }}"
       loop: "{{ Nested_Router.Interface | dict2items }}"
       when:
         - Deploy.UseDNS == true
         - Deploy.IPv6 == true
 
 
+
+
+
+
+
 ##
 ## Add Nested_ESXi Hosts
 ##
+    - name: DEBUG -- Display IPv4 'A' records for Nested_ESXi hosts
+      pause:
+        seconds: 1
+        prompt: |
+          =========================== Display Nested_ESXi DNS "A" Records =================================
+
+                                        Deploy.UseDNS: {{ Deploy.UseDNS }}
+                                    LOCAL_RecordState: {{ LOCAL_RecordState }}
+
+                                           DNS Server: {{ Common.DNS.Server1.IPv4 }}
+                                                 Zone: {{ Common.DNS.Domain }}
+                                               Record: {{ item.value.VMName }}
+                                                Value: {{ item.value.vmk.vmk0.Address.IPv4.Address }}
+
+          =================================================================================================
+      loop: "{{ Nested_ESXi.Hosts | dict2items }}"
+      when:
+        - DEBUG.DisplayVariables == true
+        - Deploy.UseDNS == true
+        - Deploy.IPv4 == true
+
+
     - name: Create IPv4 'A' records for Nested_ESXi hosts
       nsupdate:
         server:   "{{ Common.DNS.Server1.IPv4 }}"
@@ -97,23 +224,71 @@
         zone:     "{{ Common.DNS.Domain }}"
         record:   "{{ item.value.VMName }}"
         value:    "{{ item.value.vmk.vmk0.Address.IPv4.Address }}"
+        state:    "{{ LOCAL_RecordState }}"
       loop: "{{ Nested_ESXi.Hosts | dict2items }}"
       when: 
         - Deploy.UseDNS == true
         - Deploy.IPv4 == true
+
+
+
+    - name: DEBUG -- Display IPv4 'PTR' records for Nested_ESXi Hosts
+      pause:
+        seconds: 1
+        prompt: |
+          ========================== Display Nested_ESXi DNS IPv4 "PTR" Records ===========================
+
+                                        Deploy.UseDNS: {{ Deploy.UseDNS }}
+                                    LOCAL_RecordState: {{ LOCAL_RecordState }}
+
+                                           DNS Server: {{ Common.DNS.Server1.IPv4 }}
+                                                 Zone: {{ Common.DNS.Domain }}
+                                               Record: {{ item.value.vmk.vmk0.Address.IPv4.Address | ipaddr('revdns') }}
+                                                Value: {{ item.value.VMName }}.{{ Common.DNS.Domain }}.
+
+          =================================================================================================
+      loop: "{{ Nested_ESXi.Hosts | dict2items }}"
+      when:
+        - DEBUG.DisplayVariables == true
+        - Deploy.UseDNS == true
+        - Deploy.IPv4 == true
+
 
     - name: Create IPv4 'PTR' records for Nested_ESXi hosts
       nsupdate:
         server:   "{{ Common.DNS.Server1.IPv4 }}"
         type:     "PTR"
         protocol: "udp"
-        zone:     "203.10.in-addr.arpa"
         record:   "{{ item.value.vmk.vmk0.Address.IPv4.Address | ipaddr('revdns') }}"
         value:    "{{ item.value.VMName }}.{{ Common.DNS.Domain }}."
+        state:    "{{ LOCAL_RecordState }}"
       loop: "{{ Nested_ESXi.Hosts | dict2items }}"
       when: 
         - Deploy.UseDNS == true
         - Deploy.IPv4 == true
+
+
+
+    - name: DEBUG -- Display IPv6 'AAAA' records for Nested_ESXi hosts
+      pause:
+        seconds: 1
+        prompt: |
+          =========================== Display Nested_ESXi DNS "AAAA" Records ==============================
+
+                                        Deploy.UseDNS: {{ Deploy.UseDNS }}
+                                    LOCAL_RecordState: {{ LOCAL_RecordState }}
+
+                                           DNS Server: {{ Common.DNS.Server1.IPv6 }}
+                                                 Zone: {{ Common.DNS.Domain }}
+                                               Record: {{ item.value.VMName }}
+                                                Value: {{ item.value.vmk.vmk0.Address.IPv6.Address }}
+
+          =================================================================================================
+      loop: "{{ Nested_ESXi.Hosts | dict2items }}"
+      when:
+        - DEBUG.DisplayVariables == true
+        - Deploy.UseDNS == true
+        - Deploy.IPv6 == true
 
     - name: Create IPv6 'AAAA' records for Nested_ESXi hosts
       nsupdate:
@@ -123,8 +298,33 @@
         zone:     "{{ Common.DNS.Domain }}"
         record:   "{{ item.value.VMName }}"
         value:    "{{ item.value.vmk.vmk0.Address.IPv6.Address }}"
+        state:    "{{ LOCAL_RecordState }}"
       loop: "{{ Nested_ESXi.Hosts | dict2items }}"
       when: 
+        - Deploy.UseDNS == true
+        - Deploy.IPv6 == true
+
+
+
+
+    - name: DEBUG -- Display IPv6 'PTR' records for Nested_ESXi Hosts
+      pause:
+        seconds: 1
+        prompt: |
+          ========================== Display Nested_ESXi DNS IPv6 "PTR" Records ===========================
+
+                                        Deploy.UseDNS: {{ Deploy.UseDNS }}
+                                    LOCAL_RecordState: {{ LOCAL_RecordState }}
+
+                                           DNS Server: {{ Common.DNS.Server1.IPv6 }}
+                                                 Zone: {{ Common.DNS.Domain }}
+                                               Record: item.value.vmk.vmk0.Address.IPv6.Address | ipaddr('revdns') }}
+                                                Value: {{ item.value.VMName }}.{{ Common.DNS.Domain }}. 
+
+          =================================================================================================
+      loop: "{{ Nested_ESXi.Hosts | dict2items }}"
+      when:
+        - DEBUG.DisplayVariables == true
         - Deploy.UseDNS == true
         - Deploy.IPv6 == true
 
@@ -135,17 +335,37 @@
         protocol: "udp"
         record:   "{{ item.value.vmk.vmk0.Address.IPv6.Address | ipaddr('revdns') }}"
         value:    "{{ item.value.VMName }}.{{ Common.DNS.Domain }}."
+        state:    "{{ LOCAL_RecordState }}"
       loop: "{{ Nested_ESXi.Hosts | dict2items }}"
       when: 
         - Deploy.UseDNS == true
         - Deploy.IPv6 == true
-        - false                       # *TBD* Need to add IPv6 reverse zone to DNS server //LC
 
 
 
 ##
 ## Add Nested_vCenter
 ##
+    - name: DEBUG -- Display IPv4 'A' record for Nested_vCenter
+      pause:
+        seconds: 1
+        prompt: |
+          ======================== Display Nested_vCenter DNS IPv4 "A" Record =============================
+
+                                        Deploy.UseDNS: {{ Deploy.UseDNS }}
+                                    LOCAL_RecordState: {{ LOCAL_RecordState }}
+
+                                           DNS Server: {{ Common.DNS.Server1.IPv4 }}
+                                                 Zone: {{ Common.DNS.Domain }}
+                                               Record: {{ Nested_vCenter.VMName }}
+                                                Value: {{ Nested_vCenter.Address.IPv4.Address }}
+
+          =================================================================================================
+      when:
+        - DEBUG.DisplayVariables == true
+        - Deploy.UseDNS == true
+        - Deploy.IPv4 == true
+
     - name: Create IPv4 'A' records for Nested_vCenter
       nsupdate:
         server:   "{{ Common.DNS.Server1.IPv4 }}"
@@ -154,7 +374,30 @@
         zone:     "{{ Common.DNS.Domain }}"
         record:   "{{ Nested_vCenter.VMName }}"
         value:    "{{ Nested_vCenter.Address.IPv4.Address }}"
+        state:    "{{ LOCAL_RecordState }}"
       when:
+        - Deploy.UseDNS == true
+        - Deploy.IPv4 == true
+
+
+
+
+    - name: DEBUG -- Display IPv4 'PTR' record for Nested_vCenter
+      pause:
+        seconds: 1
+        prompt: |
+          ======================== Display Nested_vCenter DNS IPv4 "PTR" Record ===========================
+
+                                        Deploy.UseDNS: {{ Deploy.UseDNS }}
+                                    LOCAL_RecordState: {{ LOCAL_RecordState }}
+
+                                           DNS Server: {{ Common.DNS.Server1.IPv4 }}
+                                               Record: {{ Nested_vCenter.Address.IPv4.Address | ipaddr('revdns') }}
+                                                Value: {{ Nested_vCenter.VMName }}.{{ Common.DNS.Domain }}.
+
+          =================================================================================================
+      when:
+        - DEBUG.DisplayVariables == true
         - Deploy.UseDNS == true
         - Deploy.IPv4 == true
 
@@ -163,12 +406,35 @@
         server:   "{{ Common.DNS.Server1.IPv4 }}"
         type:     "PTR"
         protocol: "udp"
-        zone:     "203.10.in-addr.arpa"
         record:   "{{ Nested_vCenter.Address.IPv4.Address | ipaddr('revdns') }}"
         value:    "{{ Nested_vCenter.VMName }}.{{ Common.DNS.Domain }}."
+        state:    "{{ LOCAL_RecordState }}"
       when:
         - Deploy.UseDNS == true
         - Deploy.IPv4 == true
+
+
+
+
+    - name: DEBUG -- Display IPv6 'AAAA' record for Nested_vCenter
+      pause:
+        seconds: 1
+        prompt: |
+          ======================= Display Nested_vCenter DNS IPv6 "AAAA" Record ===========================
+
+                                        Deploy.UseDNS: {{ Deploy.UseDNS }}
+                                    LOCAL_RecordState: {{ LOCAL_RecordState }}
+
+                                           DNS Server: {{ Common.DNS.Server1.IPv6 }}
+                                                 Zone: {{ Common.DNS.Domain }}
+                                               Record: {{ Nested_vCenter.VMName }}
+                                                Value: {{ Nested_vCenter.Address.IPv6.Address }}
+
+          =================================================================================================
+      when:
+        - DEBUG.DisplayVariables == true
+        - Deploy.UseDNS == true
+        - Deploy.IPv6 == true
 
     - name: Create IPv6 'AAAA' records for Nested_vCenter
       nsupdate:
@@ -178,9 +444,34 @@
         zone:     "{{ Common.DNS.Domain }}"
         record:   "{{ Nested_vCenter.VMName }}"
         value:    "{{ Nested_vCenter.Address.IPv6.Address }}"
+        state:    "{{ LOCAL_RecordState }}"
       when:
         - Deploy.UseDNS == true
         - Deploy.IPv6 == true
+
+
+
+
+
+    - name: DEBUG -- Display IPv6 'PTR' record for Nested_vCenter
+      pause:
+        seconds: 1
+        prompt: |
+          ======================== Display Nested_vCenter DNS IPv6 "PTR" Record ===========================
+
+                                        Deploy.UseDNS: {{ Deploy.UseDNS }}
+                                    LOCAL_RecordState: {{ LOCAL_RecordState }}
+
+                                           DNS Server: {{ Common.DNS.Server1.IPv6 }}
+                                               Record: {{ Nested_vCenter.Address.IPv6.Address | ipaddr('revdns') }}
+                                                Value: {{ Nested_vCenter.VMName }}.{{ Common.DNS.Domain }}.
+
+          =================================================================================================
+      when:
+        - DEBUG.DisplayVariables == true
+        - Deploy.UseDNS == true
+        - Deploy.IPv6 == true
+
 
     - name: Create IPv6 'PTR' records for Nested_vCenter
       nsupdate:
@@ -189,15 +480,36 @@
         protocol: "udp"
         record:   "{{ Nested_vCenter.Address.IPv6.Address | ipaddr('revdns') }}"
         value:    "{{ Nested_vCenter.VMName }}.{{ Common.DNS.Domain }}."
+        state:    "{{ LOCAL_RecordState }}"
       when:
         - Deploy.UseDNS == true
         - Deploy.IPv6 == true
-        - false                       # *TBD* Need to add IPv6 reverse zone to DNS server //LC
 
 
 ##
 ## Add Nested_NSXT Components
 ##
+    - name: DEBUG -- Display IPv4 'A' records for Nested_NSXT
+      pause:
+        seconds: 1
+        prompt: |
+          ============================ Display Nested_NSXT DNS "A" Records ================================
+
+                                        Deploy.UseDNS: {{ Deploy.UseDNS }}
+                                    LOCAL_RecordState: {{ LOCAL_RecordState }}
+
+                                           DNS Server: {{ Common.DNS.Server1.IPv4 }}
+                                                 Zone: {{ Common.DNS.Domain }}
+                                               Record: {{ item.value.VMName }}
+                                                Value: {{ item.value.Address.IPv4.Address }}
+
+          =================================================================================================
+      loop: "{{ Nested_NSXT.Components | dict2items }}"
+      when:
+        - DEBUG.DisplayVariables == true
+        - Deploy.UseDNS == true
+        - Deploy.IPv4 == true
+
     - name: Create IPv4 'A' records for Nested_NSXT Components
       nsupdate:
         server:   "{{ Common.DNS.Server1.IPv4 }}"
@@ -206,8 +518,31 @@
         zone:     "{{ Common.DNS.Domain }}"
         record:   "{{ item.value.VMName }}"
         value:    "{{ item.value.Address.IPv4.Address }}"
+        state:    "{{ LOCAL_RecordState }}"
       loop: "{{ Nested_NSXT.Components | dict2items }}"
       when:
+        - Deploy.UseDNS == true
+        - Deploy.IPv4 == true
+
+
+
+    - name: DEBUG -- Display IPv4 'PTR' records for Nested_NSXT
+      pause:
+        seconds: 1
+        prompt: |
+          ========================== Display Nested_NSXT DNS IPv4 "PTR" Records ===========================
+
+                                        Deploy.UseDNS: {{ Deploy.UseDNS }}
+                                    LOCAL_RecordState: {{ LOCAL_RecordState }}
+
+                                           DNS Server: {{ Common.DNS.Server1.IPv4 }}
+                                               Record: {{ item.value.Address.IPv4.Address | ipaddr('revdns') }}
+                                                Value: {{ item.value.VMName }}.{{ Common.DNS.Domain }}.
+
+          =================================================================================================
+      loop: "{{ Nested_NSXT.Components | dict2items }}"
+      when:
+        - DEBUG.DisplayVariables == true
         - Deploy.UseDNS == true
         - Deploy.IPv4 == true
 
@@ -216,13 +551,36 @@
         server:   "{{ Common.DNS.Server1.IPv4 }}"
         type:     "PTR"
         protocol: "udp"
-        zone:     "203.10.in-addr.arpa"
         record:   "{{ item.value.Address.IPv4.Address | ipaddr('revdns') }}"
         value:    "{{ item.value.VMName }}.{{ Common.DNS.Domain }}."
+        state:    "{{ LOCAL_RecordState }}"
       loop: "{{ Nested_NSXT.Components | dict2items }}"
       when:
         - Deploy.UseDNS == true
         - Deploy.IPv4 == true
+
+
+
+    - name: DEBUG -- Display IPv6 'AAAA' records for Nested_NSXT
+      pause:
+        seconds: 1
+        prompt: |
+          ========================== Display Nested_NSXT DNS "AAAA" Records ===============================
+
+                                        Deploy.UseDNS: {{ Deploy.UseDNS }}
+                                    LOCAL_RecordState: {{ LOCAL_RecordState }}
+
+                                           DNS Server: {{ Common.DNS.Server1.IPv6 }}
+                                                 Zone: {{ Common.DNS.Domain }}
+                                               Record: {{ item.value.VMName }}
+                                                Value: {{ item.value.Address.IPv6.Address }}
+
+          =================================================================================================
+      loop: "{{ Nested_NSXT.Components | dict2items }}"
+      when:
+        - DEBUG.DisplayVariables == true
+        - Deploy.UseDNS == true
+        - Deploy.IPv6 == true
 
     - name: Create IPv6 'AAAA' records for Nested_NSXT Components
       nsupdate:
@@ -232,8 +590,31 @@
         zone:     "{{ Common.DNS.Domain }}"
         record:   "{{ item.value.VMName }}"
         value:    "{{ item.value.Address.IPv6.Address }}"
+        state:    "{{ LOCAL_RecordState }}"
       loop: "{{ Nested_NSXT.Components | dict2items }}"
       when:
+        - Deploy.UseDNS == true
+        - Deploy.IPv6 == true
+
+
+
+    - name: DEBUG -- Display IPv6 'PTR' records for Nested_NSXT
+      pause:
+        seconds: 1
+        prompt: |
+          ========================== Display Nested_NSXT DNS IPv6 "PTR" Records ===========================
+
+                                        Deploy.UseDNS: {{ Deploy.UseDNS }}
+                                    LOCAL_RecordState: {{ LOCAL_RecordState }}
+
+                                           DNS Server: {{ Common.DNS.Server1.IPv6 }}
+                                               Record: {{ item.value.Address.IPv6.Address | ipaddr('revdns') }}
+                                                Value: {{ item.value.VMName }}.{{ Common.DNS.Domain }}.
+
+          =================================================================================================
+      loop: "{{ Nested_NSXT.Components | dict2items }}"
+      when:
+        - DEBUG.DisplayVariables == true
         - Deploy.UseDNS == true
         - Deploy.IPv6 == true
 
@@ -242,11 +623,11 @@
         server:   "{{ Common.DNS.Server1.IPv6 }}"
         type:     "PTR"
         protocol: "udp"
-        record:   "{{ item.value.Address.IPv4.Address | ipaddr('revdns') }}"
+        record:   "{{ item.value.Address.IPv6.Address | ipaddr('revdns') }}"
         value:    "{{ item.value.VMName }}.{{ Common.DNS.Domain }}."
+        state:    "{{ LOCAL_RecordState }}"
       loop: "{{ Nested_NSXT.Components | dict2items }}"
       when:
         - Deploy.UseDNS == true
         - Deploy.IPv6 == true
-        - false                       # *TBD* Need to add IPv6 reverse zone to DNS server //LC
 

--- a/templates/vyos_router.j2
+++ b/templates/vyos_router.j2
@@ -156,12 +156,15 @@ system {
             level admin
         }
     }
+    name-server {{ Common.DNS.Server1.IPv4 }}
     ntp {
 {% if Deploy.Software.Router.Version == "Latest" %}
         listen-address {{ Nested_Router.Interface.Management.IPv4.Address }}
 {% endif %}
-        server {{ Common.NTP.Server1.IPv4 }} {
+{% for NTPServer in Nested_Router.NTP.Servers %}
+        server {{ NTPServer.IPv4.Address }} {
         }
+{% endfor %}
     }
 {% if Deploy.Software.Router.Version == "Legacy" %}
     package {


### PR DESCRIPTION
1) VyOS router (Legacy and Latest) now obtains NTP from pool.ntp.org, so make sure your lab can reach the Internet. TESTED BOTH
2) VyOS router (Legacy and Latest) is now DNS enabled, so it can resolve names.  Needed to resolve pool.ntp.org. TESTED BOTH
3) Modified deployVc.yml to only create/configure vSphere clusters and DRS if hosts are being deployed to it.  -- UNTESTED
4) updateDNS is all done, and I added a BUNCH a DEBUG in there...maybe too much, TBH.  I'm considering creating an additional DEBUG that controls showing debugs WITHING a Playbook, where the one we currently have is the summary at the top.
5) Created cleanupDNS.yml, which is reverse of updateDNS.  Used the "LOCAL_" concept here for absent/present flag. -- TESTED
