### PR TITLE
dns_hw_version

### DIFF
--- a/config_sample.yml
+++ b/config_sample.yml
@@ -482,6 +482,7 @@ Nested_DNSServer:
   VM:
     VMName: SDDC-Lab-DNS
     HardwareSettings:
+      Version: 13
       CPU: 1
       CoresPerSocket: 1
       Memory: 2048

--- a/playbooks/deployDNSServer.yml
+++ b/playbooks/deployDNSServer.yml
@@ -262,6 +262,7 @@
           type: "{{ Common.DiskProvisioning }}"
           datastore: "{{ Target.Datastore }}"
         hardware:
+          version: "{{ Nested_DNSServer.VM.HardwareSettings.Version }}"
           memory_mb: "{{ Nested_DNSServer.VM.HardwareSettings.Memory }}"
           num_cpus: "{{ Nested_DNSServer.VM.HardwareSettings.CPU }}"
           num_cpu_cores_per_socket: "{{ Nested_DNSServer.VM.HardwareSettings.CoresPerSocket }}"


### PR DESCRIPTION
Adds variable to control the hardware version of the DNS server VM. Default value is 13.