### PR TITLE
Prepare for configuration of backup jobs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -485,3 +485,5 @@
 ### Added by Luis Chanu
   - Created new "Backup" section under Common
   - Created new "Backup" section under Nested_NSXT, referencing the "Common" backup server
+  - The following files were updated so please update your non-sample files:
+    - config_sample.yml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -481,3 +481,7 @@
   - The following files were updated so please update your non-sample files:
     - config_sample.yml
     - software_sample.yml
+
+### Added by Luis Chanu
+  - Created new "Backup" section under Common
+  - Created new "Backup" section under Nested_NSXT, referencing the "Common" backup server

--- a/config_sample.yml
+++ b/config_sample.yml
@@ -135,15 +135,19 @@ Common:
     Type: nfs
   PKI:
     ValidateCerts: false                                                      # This indicates if PKI Certificates should be validated.  By default, self-signed certificates are used, so ValidateCerts should be set to 'false'
-  Backup:
-    User: "{{ Nested_DNSServer.OS.Credential.User }}"
-    Password: "{{ Nested_DNSServer.OS.Credential.Password }}"
-    Server:
-      SFTP:
-        FQDN: "{{ Nested_DServer.FQDN }}"                                     # SFTP Server FQDN
-        Path: "/home/{{ Nested_DNSServer.OS.Credential.User }}"               # Must be absolute path (i.e. Start from root '/')
   DiskProvisioning: thin
   Annotation: '*** Auto-Deployed by SDDC.Lab ***'
+
+
+##
+## Unable to put BackupServer in Common due to circular reference.  Must be stand-alone
+##
+BackupServer:
+  User: "{{ Nested_DNSServer.OS.Credential.User }}"                           # DNS server is default SFTP server, so use that credential
+  Password: "{{ Nested_DNSServer.OS.Credential.Password }}"
+  SFTP:
+    FQDN: "{{ Nested_DNSServer.FQDN }}"                                       # SFTP Server FQDN
+    Path: "/home/{{ Nested_DNSServer.OS.Credential.User }}"                   # Must be absolute path
 
 
 ##
@@ -1681,13 +1685,12 @@ Nested_NSXT:
     audit:
       Name: audit
       Password: "{{ Common.Password.Nested }}{{ Common.Password.Nested }}"
-  Backup:
-    User: "{{ Common.Backup.User }}"
-    Password: "{{ Common.Backup.Password }}"
-    Server:
-      SFTP:
-        FQDN: "{{ Common.Backup.Server.SFTP.FQDN }}"
-        Path: "{{ Common.Backup.Server.SFTP.Path }}"
+  BackupServer:
+    User: "{{ BackupServer.User }}"
+    Password: "{{ BackupServer.Password }}"
+    SFTP:
+      FQDN: "{{ BackupServer.SFTP.FQDN }}"
+      Path: "{{ BackupServer.SFTP.Path }}"
   Components:
     GlobalManager_VIP:
       VMName: "{{ Deploy.Product.NSXT.GlobalManager.SiteCode }}-NSXT-GM"

--- a/config_sample.yml
+++ b/config_sample.yml
@@ -1688,9 +1688,9 @@ Nested_NSXT:
   BackupServer:
     User: "{{ BackupServer.User }}"
     Password: "{{ BackupServer.Password }}"
-    SFTP:
-      FQDN: "{{ BackupServer.SFTP.FQDN }}"
-      Path: "{{ BackupServer.SFTP.Path }}"
+    Protocol: sftp
+    FQDN: "{{ BackupServer.SFTP.FQDN }}"
+    Path: "{{ BackupServer.SFTP.Path }}"
   Components:
     GlobalManager_VIP:
       VMName: "{{ Deploy.Product.NSXT.GlobalManager.SiteCode }}-NSXT-GM"

--- a/config_sample.yml
+++ b/config_sample.yml
@@ -140,8 +140,8 @@ Common:
     Password: "{{ Nested_DNSServer.OS.Credential.Password }}"
     Server:
       SFTP:
-        FQDN: "{{ Nested_DServer.FQDN }}"
-        Path: "/home/{{ Nested_DNSServer.OS.Credential.User }}"
+        FQDN: "{{ Nested_DServer.FQDN }}"                                     # SFTP Server FQDN
+        Path: "/home/{{ Nested_DNSServer.OS.Credential.User }}"               # Must be absolute path (i.e. Start from root '/')
   DiskProvisioning: thin
   Annotation: '*** Auto-Deployed by SDDC.Lab ***'
 

--- a/config_sample.yml
+++ b/config_sample.yml
@@ -135,6 +135,13 @@ Common:
     Type: nfs
   PKI:
     ValidateCerts: false                                                      # This indicates if PKI Certificates should be validated.  By default, self-signed certificates are used, so ValidateCerts should be set to 'false'
+  Backup:
+    User: "{{ Nested_DNSServer.OS.Credential.User }}"
+    Password: "{{ Nested_DNSServer.OS.Credential.Password }}"
+    Server:
+      SFTP:
+        FQDN: "{{ Nested_DServer.FQDN }}"
+        Path: "/home/{{ Nested_DNSServer.OS.Credential.User }}"
   DiskProvisioning: thin
   Annotation: '*** Auto-Deployed by SDDC.Lab ***'
 
@@ -1674,6 +1681,13 @@ Nested_NSXT:
     audit:
       Name: audit
       Password: "{{ Common.Password.Nested }}{{ Common.Password.Nested }}"
+  Backup:
+    User: "{{ Common.Backup.User }}"
+    Password: "{{ Common.Backup.Password }}"
+    Server:
+      SFTP:
+        FQDN: "{{ Common.Backup.Server.SFTP.FQDN }}"
+        Path: "{{ Common.Backup.Server.SFTP.Path }}"
   Components:
     GlobalManager_VIP:
       VMName: "{{ Deploy.Product.NSXT.GlobalManager.SiteCode }}-NSXT-GM"

--- a/playbooks/configureNsxBackup.yml
+++ b/playbooks/configureNsxBackup.yml
@@ -1,0 +1,279 @@
+##
+##    Project: SDDC.Lab
+##    Authors: Luis Chanu & Rutger Blom
+##   Filename: playbooks/configureNsxBackup.yml
+##
+##   Comments: This Ansible Playbook configures a backup job on NSX-T Managers deployed by this script.  After the backup is configured, a backup is performed.
+##
+---
+- hosts: localhost
+  name: configureNsxBackup.yml
+  tasks:
+    - name: configureNsxBackup_Playbook
+      ansible.builtin.debug:
+        msg: "Starting playbook: {{ ansible_play_name }}"
+
+    - name: Display error message if Pod-XXX-Config file is not valid or provided
+      ansible.builtin.pause:
+        seconds: 5
+        prompt: |
+          *****************************************************************************************************
+          ****************************************** ERROR MESSAGE ********************************************
+          *****************************************************************************************************
+
+            A valid "Pod-XXX-Config.yml" file is required in order for this playbook to run.
+
+            Please verify:
+            ==============
+              1) You supplied a valid Pod-XXX-Config.yml file via the ansible-playbook -e "@Pod-XXX-Config.yml"
+                 command-line option.  Here is an example of a how to load a Pod-XXX-Config.yml file that is
+                 located in your home directory:
+                                    ansible-playbook -e "@~/Pod-XXX-Config.yml" deploy.yml
+
+              2) The Pod-XXX-Config.yml file provided was created using the playbooks/createPodConfig.yml script.
+                 All Pod configuration files used to deploy labs MUST be generated using that script.
+
+              3) You included the proper path with the "-e" option to the Pod-XXX-Config.yml file.
+
+              4) You prefaced the file name in the "-e" option with a '@', as shown in the example above.
+
+          *****************************************************************************************************
+      when:
+        - Valid_Pod_Config_File is not defined
+
+    - name: Exit Ansible playbook if Pod-XXX-Config.yml file is not valid or provided
+      ansible.builtin.meta: end_play
+      when: Valid_Pod_Config_File is not defined
+
+
+    - name: DEBUG -- Display Target Variables (Pause)
+      ansible.builtin.pause:
+        seconds: "{{ DEBUG.DisplayDelayInSeconds }}"
+        prompt: |
+          ================================ Display Variables For Pod {{ '%03d'|format(Pod.Number|int) }} ==================================
+
+
+                                     Ansible Playbook: {{ ansible_play_name }}
+
+                                             SiteCode: {{ SiteCode }}
+
+                        NSX-T Global Manager SiteCode: {{ Deploy.Product.NSXT.GlobalManager.SiteCode }}
+                         NSX-T Local Manager SiteCode: {{ Deploy.Product.NSXT.LocalManager.SiteCode }}
+
+                               Backup Server Protocol: {{ Nested_NSXT.BackupServer.Protocol }}
+                                   Backup Server FQDN: {{ Nested_NSXT.BackupServer.FQDN }}
+                                   Backup Server Path: {{ Nested_NSXT.BackupServer.Path }}
+                                   Backup Server User: {{ Nested_NSXT.BackupServer.User }}
+
+          =================================================================================================
+      when:
+        - DEBUG.DisplayVariables == true
+
+    - name: Retrieve SSH Fingerprint for SFTP backup server
+      ansible.builtin.uri:
+        url: https://{{ Nested_NSXT.Components.LocalManager_VIP.FQDN }}/api/v1/cluster/backups?action=retrieve_ssh_fingerprint
+        url_username: "{{ Nested_NSXT.Credential.admin.Name }}"
+        url_password: "{{ Nested_NSXT.Credential.admin.Password }}"
+        validate_certs: False
+        method: POST
+        body_format: json
+        headers:
+          Content-Type: application/json
+        body: >
+          {
+            "server":"{{ Nested_NSXT.BackupServer.FQDN }}",
+            "port":22
+          }
+        timeout: 5
+      register: sftp_result
+      ignore_errors: true
+      failed_when: false
+      no_log: true
+
+    - name: Store SSH Fingerprint of SFTP Server
+      ansible.builtin.set_fact:
+        ssh_fingerprint: "{{ sftp_result.json.ssh_fingerprint | default(None) }}"
+
+    - name: DEBUG -- Display SSH Fingerprint of SFTP Server (Pause)
+      ansible.builtin.pause:
+        seconds: "{{ DEBUG.DisplayDelayInSeconds }}"
+        prompt: |
+          ================================ Display SSH Fingerprint ==================================
+
+             ssh_fingerprint: {{ ssh_fingerprint }}
+
+          ===========================================================================================
+      when:
+        - DEBUG.DisplayVariables == true
+
+
+##
+##
+######################################### STOPPED HERE -- UNTESTED ###########################################################
+##
+##
+
+    - name: If NSX-T Global Manager is part of this deployment, check if it is already installed
+      ansible.builtin.uri:
+        url: https://{{ Nested_NSXT.Components.GlobalManager.FQDN }}
+        validate_certs: False
+        timeout: 5
+      register: nsxgm_check
+      ignore_errors: true
+      failed_when: false
+      no_log: true
+      when:
+        - Deploy.Product.NSXT.GlobalManager.Deploy == true
+        - Deploy.Product.NSXT.GlobalManager.SiteCode == SiteCode
+        - false
+
+
+    - name: Wait 3 seconds before start checking whether the NSX-T Global Manager node is ready
+      ansible.builtin.pause: seconds=3
+      when: 
+        - Deploy.Product.NSXT.GlobalManager.Deploy == true
+        - Deploy.Product.NSXT.GlobalManager.SiteCode == SiteCode
+        - deployment.changed == true
+        - false
+
+    - name: Result check for NSX-T Global Manager node deployment
+      ansible.builtin.async_status:
+        jid: "{{ item.ansible_job_id }}"
+      register: job_result
+      with_items: "{{ deployment.results }}"
+      when:
+        - Deploy.Product.NSXT.GlobalManager.Deploy == true
+        - Deploy.Product.NSXT.GlobalManager.SiteCode == SiteCode
+        - deployment.changed == true
+        - item.started is defined
+        - false
+
+    - name: Wait until the NSX-T API reports that the NSX-T Global Manager cluster is "STABLE"
+      ansible.builtin.uri:
+        url: https://{{ Nested_NSXT.Components.GlobalManager.FQDN | lower }}/api/v1/cluster/status
+        validate_certs: no
+        timeout: 5
+        force_basic_auth: yes
+        url_username: "{{ Nested_NSXT.Credential.admin.Name }}"
+        url_password: "{{ Nested_NSXT.Credential.admin.Password }}"
+        method: GET
+        body_format: json
+        return_content: yes
+        status_code: 200
+      register: result
+      until: result.status == 200 and result.json.detailed_cluster_status.overall_status == "STABLE"
+      retries: 60
+      delay: 60
+      when:
+        - Deploy.Product.NSXT.GlobalManager.Deploy == true
+        - Deploy.Product.NSXT.GlobalManager.SiteCode == SiteCode
+        - false
+
+    - name: Configure NSX-T Global Manager Virtual IP (VIP) Address
+      nsxt_virtual_ip:
+        hostname: "{{ Nested_NSXT.Components.GlobalManager.FQDN }}"
+        username: "{{ Nested_NSXT.Credential.admin.Name }}"
+        password: "{{ Nested_NSXT.Credential.admin.Password }}"
+        validate_certs: false
+        virtual_ip_address: "{{ Nested_NSXT.Components.GlobalManager_VIP.Address.IPv4.Address }}"
+        state: present
+      when:
+        - Deploy.Product.NSXT.GlobalManager.Deploy == true
+        - Deploy.Product.NSXT.GlobalManager.SiteCode == SiteCode
+        - false
+
+    - name: Wait until the NSX-T API reports that the NSX-T Global Manager cluster is "STABLE" on the VIP
+      ansible.builtin.uri:
+        url: https://{{ Nested_NSXT.Components.GlobalManager_VIP.Address.IPv4.Address }}/api/v1/cluster/status
+        validate_certs: no
+        timeout: 5
+        force_basic_auth: yes
+        url_username: "{{ Nested_NSXT.Credential.admin.Name }}"
+        url_password: "{{ Nested_NSXT.Credential.admin.Password }}"
+        method: GET
+        body_format: json
+        return_content: yes
+        status_code: 200
+      register: result
+      until: result.status == 200 and result.json.detailed_cluster_status.overall_status == "STABLE"
+      retries: 60
+      delay: 60
+      when:
+        - Deploy.Product.NSXT.GlobalManager.Deploy == true
+        - Deploy.Product.NSXT.GlobalManager.SiteCode == SiteCode
+        - false
+
+    - name: Enable and Activate NSX-T Global Manager
+      nsxt_global_manager_enable_service:
+        hostname: "{{ Nested_NSXT.Components.GlobalManager_VIP.FQDN }}"
+        username: "{{ Nested_NSXT.Credential.admin.Name }}"
+        password: "{{ Nested_NSXT.Credential.admin.Password }}"
+        validate_certs: False
+        display_name: "{{ Nested_NSXT.Components.GlobalManager_VIP.VMName }}"
+        id: "{{ Nested_NSXT.Components.GlobalManager_VIP.VMName }}"
+      when:
+        - Deploy.Product.NSXT.GlobalManager.Deploy == true
+        - Deploy.Product.NSXT.GlobalManager.SiteCode == SiteCode
+        - false
+
+    - name: Write annotation on the NSX-T Global Manager VM
+      community.vmware.vmware_guest:
+        hostname: "{{ Target.FQDN }}"
+        username: "{{ Target.User }}"
+        password: "{{ Target.Password }}"
+        validate_certs: no
+        cluster: "{{ Target.Cluster }}"
+        datacenter: "{{ Target.DataCenter }}"
+        folder: "{{ Target.VMFolder }}"
+        name: "{{ Nested_NSXT.Components.GlobalManager.VMName }}"
+        annotation: | 
+                    {{ Common.Annotation }}
+                    {{ Deploy.Software.NSXT.Vendor }} {{ Deploy.Software.NSXT.Product}} {{ Deploy.Software.NSXT.Version }}
+                    Username: {{ Nested_NSXT.Credential.admin.Name }}
+                    Password: {{ Nested_NSXT.Credential.admin.Password }}
+      when: 
+        - Deploy.Product.NSXT.GlobalManager.Deploy == true
+        - Deploy.Product.NSXT.GlobalManager.SiteCode == SiteCode
+        - false
+
+
+##
+## Disable Password Expiration for all users except for root (API does not permit disabling for 'root' user)
+##
+    - name: Obtain NSX-T Global Manager User List
+      ansible.builtin.uri:
+        url: https://{{ Nested_NSXT.Components.GlobalManager.FQDN | lower }}/api/v1/node/users
+        validate_certs: no
+        timeout: 15
+        force_basic_auth: yes
+        url_username: "{{ Nested_NSXT.Credential.admin.Name }}"
+        url_password: "{{ Nested_NSXT.Credential.admin.Password }}"
+        method: GET
+        body_format: json
+        return_content: yes
+        status_code: 200
+      register: UserList
+      when: 
+        - Deploy.Product.NSXT.GlobalManager.Deploy == true
+        - Deploy.Product.NSXT.GlobalManager.SiteCode == SiteCode
+        - false
+
+    - name: Disable Password Expiration Of All NSX-T Users (except for 'root')
+      ansible.builtin.uri:
+        url: https://{{ Nested_NSXT.Components.GlobalManager.FQDN | lower }}/api/v1/node/users/{{ item.userid }}
+        validate_certs: no
+        timeout: 15
+        force_basic_auth: yes
+        url_username: "{{ Nested_NSXT.Credential.admin.Name }}"
+        url_password: "{{ Nested_NSXT.Credential.admin.Password }}"
+        method: PUT
+        body_format: json
+        body: '{ "password_change_frequency": 0 }'
+        return_content: yes
+        status_code: 200
+      loop: "{{ UserList.json.results }}"
+      when: 
+        - Deploy.Product.NSXT.GlobalManager.Deploy == true
+        - Deploy.Product.NSXT.GlobalManager.SiteCode == SiteCode
+        - item.userid > 0
+        - false

--- a/templates/Pod_Config.j2
+++ b/templates/Pod_Config.j2
@@ -156,6 +156,10 @@ Common:
   {{ Common | to_nice_yaml(indent=2, width=99999) | indent(2) }}
 
 
+BackupServer:
+  {{ BackupServer | to_nice_yaml(indent=2, width=99999) | indent(2) }}
+
+
 Target:
   {{ Target | to_nice_yaml(indent=2, width=99999) | indent(2) }}
 


### PR DESCRIPTION
1. Modified config_sample.yml with "Common" backup job.  Unable to place in "Common" structure due to circular references, so had to place at top level.
2. Started "configureNsxBackup.yml" playbook
3. Updated Pod_Config.j2 template to add additional "BackupServer" top-level variable.

Goal of top-level BackupServer structure is to list multiple backup servers, if needed, each supporting a different protocol.  Then, each product would use the server that made sense.   See "Nested_NSXT" structure for example use.