### PR TITLE
Preparing for NSX-T v3.2.0 Support, but not yet working.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -802,3 +802,12 @@
     - VCSA v7.00U3A, ESXi 7.00U3, NSX-T v3.1.3.5 (Standalone)
   - The following deployment scenarios **FAILED**:
     - VCSA v7.00U3A, ESXi 7.00U3, NSX-T v3.2.0   (Standalone) -- Issue with EdgeVM state changes when password aging is cleared (Flaps from SUCCESS to IN_PROGRESS), then Edge Cluster creation fails.
+
+## Dev-v4.0.0 26-DEC-2021
+
+### Added by Luis Chanu
+  - Modified createNsxEdgeCluster.yml play to address the flapping of EdgeVM state when the user password aging is disabled.
+  - The following deployment scenarios completed successfully:
+    - VCSA v7.00U3A, ESXi 7.00U3, NSX-T v3.1.3.3 (2-Site Federation)
+    - VCSA v7.00U3A, ESXi 7.00U3, NSX-T v3.1.3.5 (Standalone)
+    - VCSA v7.00U3A, ESXi 7.00U3, NSX-T v3.2.0   (Standalone)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -775,3 +775,30 @@
     - VCSA version (VCSAvXXXXX) where XXXXX is VCSA version
     - NSXT version (NSXTvYYYYY) where YYYYY is NSX-T version
     - Fed-Z where Z is either Y or N, and indicates whether the Pod Configuration has NSX-T Federation deployment enabled or not
+
+## Dev-v4.0.0 24-DEC-2021
+
+### Added by Luis Chanu
+  - **IMPORTANT**: As part of NSX-T Federation, NSX-T v3.2.0 appears to not support importing objects from a Location into the Global Manager.  For this reason, SDDC.Lab can not be used to deploy Federation when deploying NSX-T v3.2.0, as SDDC.Lab utilizes this functionality.  The workaround to this is to deploy Federation using NSX-T v3.1.3.3, then manually upgrade the Pods to v3.2.0.  It's assumed that this functionality will be re-introduced in a later release.  Standalone (i.e. Non-Federated) deployments of NSX-T v3.2.0 has been tested, and works fine.
+  - NSX-T v3.2.0 Federation details added to README.md file
+  - NSX-T v3.2.0 takes MUCH longer to set the "password_change_frequency" on an Edge Transport Node users than it did under NSX-T v3.1.3.3.  For this reason, the timeout on the task that performs this operation within "createNsxEdgeTn.yml" playbook has been increased from 15 to 60 seconds.
+  - NSX-T Version Tested Status:
+    - v3.1.3.3: Standalone and Federation
+    - v3.1.3.5: We are still looking into an issue when deploying against this version.  Until further testing has been done, please do not deploy directly to this version...use v3.1.3.3 instead, then manually upgrade to v3.1.3.5.
+    - v3.2.0:   Standalone only (See 'IMPORTANT' comment above)
+  - Manually edited Ansible module "nsxt_fabric_compute_managers.py" to incorporate a change that was made in the VMware NSX-T Ansible modules to support Compute Manager registartion under NSX-T v3.2.0.
+  - The "var_NSXT_EdgeTransportNodes.j2" template has been updated to support v3.2.0.  These changes have also been tested against v3.1.3.3, and deployed fine.
+  - Modified "createPodConfig.yml" to append the Global Manager Pod to the end of the filename if Federation is enabled.
+  - The following playbooks have been modified to support NSX-T v3.2.0:
+    - createNsxEdgeTn.yml
+    - createNsxTz.yml
+
+## Dev-v4.0.0 25-DEC-2021
+
+### Added by Luis Chanu
+  - Increased retry count on vSphere Replication partner in checkVcReplicaionPartner.yml from 30 to 45.  This is to ensure very large deployments don't timeout during deployment.  Have not run into any issues, just a preventative measure.
+  - The following deployment scenarios completed successfully:
+    - VCSA v7.00U3A, ESXi 7.00U3, NSX-T v3.1.3.3 (2-Site Federation)
+    - VCSA v7.00U3A, ESXi 7.00U3, NSX-T v3.1.3.5 (Standalone)
+  - The following deployment scenarios **FAILED**:
+    - VCSA v7.00U3A, ESXi 7.00U3, NSX-T v3.2.0   (Standalone) -- Issue with EdgeVM state changes when password aging is cleared (Flaps from SUCCESS to IN_PROGRESS), then Edge Cluster creation fails.

--- a/README.md
+++ b/README.md
@@ -275,6 +275,8 @@ When deploying NSX-T Federation, keep the following in mind:
 
 9. The **config_sample.yml** default configuration assumes the Lab-Routers transit segment, and thus communication between NSX-T Federation Locations, is configured with an MTU of 1500 bytes.  If your environment supports Jumbo Frames, you can obtain better performance by changing the MTU values in the Net section.  Keep in mind that the OSPF (by default) requires matching MTU sizes, so you may lose peering with your ToR router.  If you decide to change the MTU values, you need to take this all into account, and are on your own.  For a lab, the default 1500 byte MTU configurations should suffice.
 
+10. SDDC.Lab does not support Federation with NSX-T v3.2.0.  If you want to deploy Federation in your lab, deploy Federation using NSX-T v3.1.3.3, then manually upgrade the Pods to NSX-T v3.2.0.
+
 ### vSphere Content Libraries
 SDDC.Lab now supports both local and subscribed vSphere Content Libraries, which can be very helpful in a lab environment by centralizing workload ISOs and VMs (i.e. On the physical vCenter Server or a stand-alone Content Library target), then accessing them via the deployed Pods.  There are a few things to keep in mind with Content Libraries:
 

--- a/library/__Module_Info
+++ b/library/__Module_Info
@@ -3,7 +3,7 @@ The files located in the following directories were obtain from the VMware NSX-T
    2) ../module_utils
    3) ../plugins
 
-There were obtained on March 21, 2021.
+There were obtained on March 21, 2021, althought the "nsxt_fabric_compute_managers.py" module was manually updated to support v3.2.0.
 
 The GitHub URL to the VMware NSX-T Ansible module repository is: https://github.com/vmware/ansible-for-nsxt
 

--- a/library/nsxt_fabric_compute_managers.py
+++ b/library/nsxt_fabric_compute_managers.py
@@ -191,7 +191,7 @@ def wait_till_create(id, module, manager_url, mgr_username, mgr_password, valida
       while True:
           (rc, resp) = request(manager_url+ '/fabric/compute-managers/%s/status'% id, headers=dict(Accept='application/json'),
                         url_username=mgr_username, url_password=mgr_password, validate_certs=validate_certs, ignore_errors=True)
-          if resp['registration_status'] == "REGISTERING":
+          if resp['registration_status'] == "REGISTERING" or resp['registration_status'] == "UNREGISTERED":
               time.sleep(10)
           elif resp['registration_status'] == "REGISTERED":
             if resp["connection_status"] == "CONNECTING":

--- a/playbooks/checkVcReplicationPartner.yml
+++ b/playbooks/checkVcReplicationPartner.yml
@@ -150,7 +150,7 @@
         status_code: 200
       register: health_result
       until:    health_result.status == 200 and health_result.json.value == "green"
-      retries: 30
+      retries: 45
       delay: 60
       when:
         - vCenter_SessionID is defined

--- a/playbooks/createNsxEdgeCluster.yml
+++ b/playbooks/createNsxEdgeCluster.yml
@@ -96,14 +96,6 @@
 ## NOT in "SUCCESS" state, the Edge Cluster creation play will fail.  For that reason, we need to verify that all of
 ## the EdgeVM Nodes are in "SUCCESS" state before we proceed with the Edge Cluster creation.
 ##
-    - name: Add delay to allow all EdgeVM nodes to reach 'SUCCESS' state
-      ansible.builtin.pause:
-        minutes: 1
-      when: 
-        - Deploy.Product.NSXT.LocalManager.Deploy == true
-        - Deploy.Product.NSXT.Edge.Deploy == true
-        - var_EdgeClusters != ""
-
     - name:  Wait until all Edge Nodes deployed report as being in a realized 'SUCCESS' state
       ansible.builtin.uri:
         url: https://{{ Nested_NSXT.Component.LocalManager_VIP.FQDN }}/api/v1/transport-nodes/state?status=SUCCESS

--- a/playbooks/createNsxEdgeCluster.yml
+++ b/playbooks/createNsxEdgeCluster.yml
@@ -59,6 +59,7 @@
 
                   Nested_NSXT.Component.LocalManager_VIP.FQDN: {{ Nested_NSXT.Component.LocalManager_VIP.FQDN }}
 
+                               Number of Edge Transport Nodes: {{ Nested_NSXT.System.Fabric.Nodes.EdgeTransportNodes | length }}
            Nested_NSXT.System.Fabric.Nodes.EdgeTransportNodes: {{ Nested_NSXT.System.Fabric.Nodes.EdgeTransportNodes }}
 
           =================================================================================================
@@ -79,7 +80,8 @@
         prompt: |
           ================================ Display var_EdgeClusters Variable ===================================
 
-              var_EdgeTransportNodes: {{ var_EdgeClusters | to_nice_yaml(indent=2) }}
+          var_EdgeTransportNodes:
+            {{ var_EdgeClusters | to_nice_yaml(indent=2, width=99999) | indent(2) }}
 
           =================================================================================================
       when:
@@ -88,6 +90,50 @@
         - var_EdgeClusters != ""
 
 
+##
+## In NSX-T v3.2.0, during the task where User Accounts password aging is set to 0 (==Do Not Expire), the EdgeVM nodes 
+## transition into "IN_PROGRESS" states for each User Account that is reconfigured.  If any of the Edge VM nodes are 
+## NOT in "SUCCESS" state, the Edge Cluster creation play will fail.  For that reason, we need to verify that all of
+## the EdgeVM Nodes are in "SUCCESS" state before we proceed with the Edge Cluster creation.
+##
+    - name: Add delay to allow all EdgeVM nodes to reach 'SUCCESS' state
+      ansible.builtin.pause:
+        minutes: 1
+      when: 
+        - Deploy.Product.NSXT.LocalManager.Deploy == true
+        - Deploy.Product.NSXT.Edge.Deploy == true
+        - var_EdgeClusters != ""
+
+    - name:  Wait until all Edge Nodes deployed report as being in a realized 'SUCCESS' state
+      ansible.builtin.uri:
+        url: https://{{ Nested_NSXT.Component.LocalManager_VIP.FQDN }}/api/v1/transport-nodes/state?status=SUCCESS
+        url_username: "{{ Nested_NSXT.Credential.admin.Name }}"
+        url_password: "{{ Nested_NSXT.Credential.admin.Password }}"
+        validate_certs: "{{ Common.PKI.ValidateCerts }}"
+        timeout: 20
+        force_basic_auth: yes
+        method: GET
+        body_format: json
+        return_content: yes
+        status_code: 200
+      register: result
+      until: result.status == 200 and ((result | community.general.json_query(query) | length) == (Nested_NSXT.System.Fabric.Nodes.EdgeTransportNodes | length))
+      retries: 10
+      delay: 30
+      vars:
+        # JSON Query returns all EdgeVMs from the list of ALL the Transport Nodes (Host & Edges) we received from the REST API call
+        query: json.results[?node_deployment_state.state=='NODE_READY']
+      when: 
+        - Deploy.Product.NSXT.LocalManager.Deploy == true
+        - Deploy.Product.NSXT.Edge.Deploy == true
+        - var_EdgeClusters != ""
+
+
+
+
+##
+## At this point, all EdgeVMs are in a "SUCCESS" state, so we can proceed with creating the Edge Cluster.
+##
     - name: Create NSX-T Edge Cluster
       nsxt_edge_clusters:
         hostname: "{{ Nested_NSXT.Component.LocalManager_VIP.FQDN }}"
@@ -110,11 +156,11 @@
     - name:  Wait until the NSX-T API reports that the Edge Cluster is in realized state
       ansible.builtin.uri:
         url: https://{{ Nested_NSXT.Component.LocalManager_VIP.FQDN }}/policy/api/v1/infra/sites/default/enforcement-points/default/edge-clusters/{{ edge_cluster | json_query('results[].id') | first }}
-        validate_certs: "{{ Common.PKI.ValidateCerts }}"
-        timeout: 5
-        force_basic_auth: yes
         url_username: "{{ Nested_NSXT.Credential.admin.Name }}"
         url_password: "{{ Nested_NSXT.Credential.admin.Password }}"
+        validate_certs: "{{ Common.PKI.ValidateCerts }}"
+        timeout: 15
+        force_basic_auth: yes
         method: GET
         body_format: json
         return_content: yes

--- a/playbooks/createNsxEdgeTn.yml
+++ b/playbooks/createNsxEdgeTn.yml
@@ -372,7 +372,7 @@
       ansible.builtin.uri:
         url: https://{{ Nested_NSXT.Component.LocalManager_VIP.FQDN }}/api/v1/transport-nodes/{{ item.0 }}/node/users/{{ item.1.userid }}
         validate_certs: "{{ Common.PKI.ValidateCerts }}"
-        timeout: 15
+        timeout: 60
         force_basic_auth: yes
         url_username: "{{ Nested_NSXT.Credential.admin.Name }}"
         url_password: "{{ Nested_NSXT.Credential.admin.Password }}"

--- a/playbooks/createNsxEdgeTn.yml
+++ b/playbooks/createNsxEdgeTn.yml
@@ -391,3 +391,18 @@
       when: 
         - Deploy.Product.NSXT.LocalManager.Deploy == true
         - Deploy.Product.NSXT.Edge.Deploy == true
+
+
+##
+## In NSX-T v3.2.0, in the previous task where the User Accounts password change frequency is set to 0 (==Do Not Expire),
+## the EdgeVM nodes briefly transition into "IN_PROGRESS" states for each User Account that is reconfigured before
+## returning to the "SUCCESS" state.  To ensure subsequent playbooks don't run into any issues with an EdgeVM not being
+## in the "SUCCESS" state, a small delay is introduced.
+##
+    - name: Add delay to allow all EdgeVM nodes to reach 'SUCCESS' state
+      ansible.builtin.pause:
+        minutes: 1
+      when: 
+        - Deploy.Product.NSXT.LocalManager.Deploy == true
+        - Deploy.Product.NSXT.Edge.Deploy == true
+

--- a/playbooks/createNsxTz.yml
+++ b/playbooks/createNsxTz.yml
@@ -83,8 +83,8 @@
         is_default: "{{ item.value.SetAsDefault }}"
         description: "{{ item.value.Description }}"
         transport_type: "{{ item.value.Type }}"
-        host_switch_name: "{{ item.value.Switch }}"
-        host_switch_mode: "STANDARD"
+#        host_switch_name: "{{ item.value.Switch }}" _320_
+#        host_switch_mode: "STANDARD" _320_
         state: "present"
       register: result
       loop: "{{ Nested_NSXT.System.Fabric.TransportZone | dict2items }}"

--- a/playbooks/createPodConfig.yml
+++ b/playbooks/createPodConfig.yml
@@ -14,7 +14,7 @@
   vars:
     - PodTemplate: "Pod_Config.j2"
     - PodTempConfigFile: "{{ SiteCode }}-Config_Temp.yml"
-    - PodConfigFile: "{{ SiteCode }}-Config_VCSAv{{ Deploy.Software.vCenter.Version }}_NSXTv{{ Deploy.Software.NSXT.Version }}_Fed-{% if Deploy.Product.NSXT.Federation.Enable == true %}Y_{{ Deploy.Product.NSXT.GlobalManager.SiteCode }}{% else %}N{% endif %}.yml"
+    - PodConfigFile: "{{ SiteCode }}-Config_VCSAv{{ Deploy.Software.vCenter.Version }}_ESXIv{{ Deploy.Software.ESXi.Version }}_NSXTv{% if Deploy.Product.NSXT.LocalManager.Deploy == false %}NONE{% else %}{{ Deploy.Software.NSXT.Version }}_Fed-{% if Deploy.Product.NSXT.Federation.Enable == true %}Y_{{ Deploy.Product.NSXT.GlobalManager.SiteCode }}{% else %}N{% endif %}{% endif %}.yml"
 
   vars_prompt:
 

--- a/playbooks/deployNsxLocalManager.yml
+++ b/playbooks/deployNsxLocalManager.yml
@@ -102,7 +102,7 @@
       ansible.builtin.uri:
         url: https://{{ Nested_NSXT.Component.LocalManager.FQDN }}
         validate_certs: "{{ Common.PKI.ValidateCerts }}"
-        timeout: 5
+        timeout: 15
       register: nsxman_check
       ignore_errors: true
       failed_when: false
@@ -175,7 +175,7 @@
       ansible.builtin.uri:
         url: https://{{ Nested_NSXT.Component.LocalManager.FQDN }}/api/v1/cluster/status
         validate_certs: "{{ Common.PKI.ValidateCerts }}"
-        timeout: 5
+        timeout: 15
         force_basic_auth: yes
         url_username: "{{ Nested_NSXT.Credential.admin.Name }}"
         url_password: "{{ Nested_NSXT.Credential.admin.Password }}"
@@ -194,7 +194,7 @@
       ansible.builtin.uri:
         url: https://{{ Nested_NSXT.Component.LocalManager.FQDN }}/api/v1/cluster/api-virtual-ip?action=set_virtual_ip&ip_address={{ Nested_NSXT.Component.LocalManager_VIP.Address.IPv4.Address }}
         validate_certs: "{{ Common.PKI.ValidateCerts }}"
-        timeout: 5
+        timeout: 15
         force_basic_auth: yes
         url_username: "{{ Nested_NSXT.Credential.admin.Name }}"
         url_password: "{{ Nested_NSXT.Credential.admin.Password }}"
@@ -213,7 +213,7 @@
       ansible.builtin.uri:
         url: https://{{ Nested_NSXT.Component.LocalManager_VIP.FQDN }}/api/v1/cluster/status
         validate_certs: "{{ Common.PKI.ValidateCerts }}"
-        timeout: 5
+        timeout: 15
         force_basic_auth: yes
         url_username: "{{ Nested_NSXT.Credential.admin.Name }}"
         url_password: "{{ Nested_NSXT.Credential.admin.Password }}"

--- a/playbooks/validateConfiguration.yml
+++ b/playbooks/validateConfiguration.yml
@@ -146,6 +146,35 @@
 
 
 ##
+## Verify the following two options are not set, as Federation with NSX-T v3.2.0 is not supported:
+##     Deploy.Product.NSXT.Federation.Enable == True
+##     Deploy.Software.NSXT.Version == '3.2.0'
+##
+    - name: Verify Federation Support
+      ansible.builtin.pause:
+        seconds: 5
+        prompt: |
+          =================================== Configuration Issue Found ===================================
+
+                        Issue: Deploying Federation on NSX-T v3.2.0 is not supported
+
+            Configured Values: Deploy.Product.NSXT.Federation.Enable == {{ Deploy.Product.NSXT.Federation.Enable }}
+                               Deploy.Software.NSXT.Version == {{ Deploy.Software.NSXT.Version }}
+
+          =================================================================================================
+      when:
+        - Deploy.Product.NSXT.Federation.Enable == True
+        - Deploy.Software.NSXT.Version == '3.2.0'
+
+    - name: Set flag if issue found with Pod.BaseNetwork.IPv6
+      ansible.builtin.set_fact:
+        IssueFound: true
+      when:
+        - Deploy.Product.NSXT.Federation.Enable == True
+        - Deploy.Software.NSXT.Version == '3.2.0'
+
+
+##
 ## Verify Pod.BaseNetwork.IPv6 is 17 characters long and makes a valid /56 prefix
 ##
     - name: Verify Pod.BaseNetwork.IPv6

--- a/templates/vars_NSXT_EdgeTransportNodes.j2
+++ b/templates/vars_NSXT_EdgeTransportNodes.j2
@@ -3,6 +3,7 @@
  #   Filename: templates/var_NSXT_EdgeTransportNodes.j2
  #    Used By: This file is used by the playbook createNsxEdgeTn.yml
  #    Purpose: This Jinja2 template file is used to create the data structure that is provided to the nsxt_transport_nodes module.
+ #      NSX-T: Structure updated to support NSX-T v3.2.0
  #
  #}
 {% for EdgeTransportNode in Nested_NSXT.System.Fabric.Nodes.EdgeTransportNodes %}
@@ -52,20 +53,6 @@
           audit_username: "{{ EdgeTransportNode.Deployment.AuditUsername }}"
           audit_password: "{{ EdgeTransportNode.Deployment.AuditPassword }}"
         vm_deployment_config:
-          enable_ssh: "{{ EdgeTransportNode.Deployment.EnableSSH }}"
-          allow_ssh_root_login: "{{ EdgeTransportNode.Deployment.AllowRootSSH }}"
-          search_domains:
-            - "{{ Common.DNS.Domain }}"
-          dns_servers:
-            - "{{ Common.DNS.Server1.IPv4 }}"
-{% if Common.DNS.Server2.IPv4 %}
-            - "{{ Common.DNS.Server2.IPv4 }}"
-{% endif %}
-          ntp_servers:
-            - "{{ Common.NTP.Server1.IPv4 }}"
-{% if Common.NTP.Server2.IPv4 %}
-            - "{{ Common.NTP.Server2.IPv4 }}"
-{% endif %}
           placement_type: VsphereDeploymentConfig
           vc_name: "{{ EdgeTransportNode.Deployment.vCenterName }}"
           vc_username: "{{ EdgeTransportNode.Deployment.vCenterUser }}"
@@ -81,7 +68,6 @@
             prefix_length: "{{ EdgeTransportNode.Deployment.ManagementIPPrefix }}"
           default_gateway_addresses: 
           - "{{ EdgeTransportNode.Deployment.Gateway }}"
-          hostname: "{{ EdgeTransportNode.Deployment.Hostname }}"
           compute: "{{ Nested_NSXT.System.Fabric.Nodes.vSphereEdgeCluster }}"
           storage: "{{ EdgeTransportNode.Deployment.Datastore }}"
           host: "{{ EdgeHosts[(loop.index0 % (EdgeHosts|length))] }}"
@@ -91,4 +77,21 @@
               reservation_in_shares: "{{ EdgeTransportNode.Deployment.Reservations.CPU.Shares }}"
             memory_reservation:
               reservation_percentage: "{{ EdgeTransportNode.Deployment.Reservations.Memory.Percentage }}"
+      node_settings:
+          hostname: "{{ EdgeTransportNode.Deployment.Hostname }}"
+          allow_ssh_root_login: "{{ EdgeTransportNode.Deployment.AllowRootSSH }}"
+          enable_ssh: "{{ EdgeTransportNode.Deployment.EnableSSH }}"
+          search_domains:
+            - "{{ Common.DNS.Domain }}"
+          dns_servers:
+            - "{{ Common.DNS.Server1.IPv4 }}"
+{% if Common.DNS.Server2.IPv4 %}
+            - "{{ Common.DNS.Server2.IPv4 }}"
+{% endif %}{# DNS.Server2 #}
+          ntp_servers:
+            - "{{ Common.NTP.Server1.IPv4 }}"
+{% if Common.NTP.Server2.IPv4 %}
+            - "{{ Common.NTP.Server2.IPv4 }}"
+{% endif %}{# NTP.Server2 #}
+
 {% endfor %}{# EdgeTransportNode #}

--- a/tests/CreateNsxTz.yml
+++ b/tests/CreateNsxTz.yml
@@ -1,0 +1,23 @@
+##
+##    Project: SDDC.Lab
+##    Authors: Luis Chanu & Rutger Blom
+##   Filename: tests/CreateNsxTz.yml
+##
+---
+- hosts: localhost
+  tasks:
+    - name: Create NSX-T transport zones
+      nsxt_transport_zones:
+        hostname: Pod-050-NSXT-LM-1.SDDC.Lab
+        username: admin
+        password: VMware1!VMware1!
+        validate_certs: false
+        resource_type: TransportZone
+        display_name: TZ-Test-DeleteMe
+        is_default: false
+        description: This is a dummy test TZ
+        transport_type: OVERLAY
+#        host_switch_name: "{{ item.value.Switch }}"
+#        host_switch_mode: "STANDARD"
+        state: present
+      register: result

--- a/tests/_Deprecated-APIs.md
+++ b/tests/_Deprecated-APIs.md
@@ -3,11 +3,19 @@
 ## NSX-T REST API Documentation (Main Page)
   - [NSX-T v3.1.2](https://developer.vmware.com/apis/1163/nsx-t)
   - [NSX-T v3.2.0](https://developer.vmware.com/apis/1198/nsx-t)
+  - [NSX-T v3.2.0 Release Notes (shows all deprecated REST API calls)](https://docs.vmware.com/en/VMware-NSX-T-Data-Center/3.2/rn/vmware-nsxt-data-center-32-release-notes/index.html)
+
+
+## Additional Notes
+  - When an NSX-T depreacated REST API call is used, the header returns a warning in the error as follows:\
+"warning": "299 - \\"Deprecated API\\""
+
+If we do a full deployment, and can log the console output, then we can track which API calls are showing up as being deprecated.
 
 
 ## Deprecated API Usage
 
-| Playbook(s) | NSX-T v3.2.0 API Section | Deprecated API | Replacement API | New API Works v3.1.x | New API Works v3.2.0 | Comments |
+| Playbook(s) | NSX-T v3.2.0 API Section | Deprecated API | Replacement API | New API Works in v3.1.x | New API Works in v3.2.0 | Comments |
 | :---        | :---        | :---        | :---        | :---        | :---        | :---        |
 | createNsxEdgeTn.yml | [Transport Nodes](https://vdc-download.vmware.com/vmwb-repository/dcr-public/ce4128ae-8334-4f91-871b-ecce254cf69e/488f1280-204c-441d-8520-8279ac33d54b/api_includes/system_administration_configuration_fabric_nodes_transport_nodes.html) | [GET /api/v1/transport-nodes](https://vdc-download.vmware.com/vmwb-repository/dcr-public/ce4128ae-8334-4f91-871b-ecce254cf69e/488f1280-204c-441d-8520-8279ac33d54b/api_includes/method_ListTransportNodesWithDeploymentInfo.html) | [GET /policy/api/v1/infra/sites/\<site-id\>/enforcement-points/\<enforcementpoint-id\>/host-transport-nodes/state](https://vdc-download.vmware.com/vmwb-repository/dcr-public/ce4128ae-8334-4f91-871b-ecce254cf69e/488f1280-204c-441d-8520-8279ac33d54b/api_includes/method_ListHostTransportNodesByState.html) | No | Yes | When used against a Local Manager, use "default" for both \<site-id\> and \<enforcementpoint-id\>. |
 

--- a/tests/_Deprecated-APIs.md
+++ b/tests/_Deprecated-APIs.md
@@ -1,0 +1,13 @@
+# Known Deprecated REST API Calls Used In SDDC.Lab
+
+## NSX-T REST API Documentation (Main Page)
+  - [NSX-T v3.1.2](https://developer.vmware.com/apis/1163/nsx-t)
+  - [NSX-T v3.2.0](https://developer.vmware.com/apis/1198/nsx-t)
+
+
+## Deprecated API Usage
+
+| Playbook(s) | NSX-T v3.2.0 API Section | Deprecated API | Replacement API | New API Works v3.1.x | New API Works v3.2.0 | Comments |
+| :---        | :---        | :---        | :---        | :---        | :---        | :---        |
+| createNsxEdgeTn.yml | [Transport Nodes](https://vdc-download.vmware.com/vmwb-repository/dcr-public/ce4128ae-8334-4f91-871b-ecce254cf69e/488f1280-204c-441d-8520-8279ac33d54b/api_includes/system_administration_configuration_fabric_nodes_transport_nodes.html) | [GET /api/v1/transport-nodes](https://vdc-download.vmware.com/vmwb-repository/dcr-public/ce4128ae-8334-4f91-871b-ecce254cf69e/488f1280-204c-441d-8520-8279ac33d54b/api_includes/method_ListTransportNodesWithDeploymentInfo.html) | [GET /policy/api/v1/infra/sites/\<site-id\>/enforcement-points/\<enforcementpoint-id\>/host-transport-nodes/state](https://vdc-download.vmware.com/vmwb-repository/dcr-public/ce4128ae-8334-4f91-871b-ecce254cf69e/488f1280-204c-441d-8520-8279ac33d54b/api_includes/method_ListHostTransportNodesByState.html) | No | Yes | When used against a Local Manager, use "default" for both \<site-id\> and \<enforcementpoint-id\>. |
+

--- a/utils/_UpdateDNSRecords.TXT
+++ b/utils/_UpdateDNSRecords.TXT
@@ -2,8 +2,8 @@ Example on how to add 'A' and 'PTR' records to DNS using 'nsupdate':
 
 # nsupdate
 > server 10.203.0.5
-> update add newhost.sddc.lab 3600 A 10.203.100.10
-> update add 10.100.203.10.in-addr.arpa. 3600 PTR newhost.sddc.lab.
+> update add newhost.SDDC.Lab. 3600 A 10.203.100.10
+> update add 10.100.203.10.in-addr.arpa. 3600 PTR newhost.SDDC.Lab.
 > send
 > quit
 
@@ -13,7 +13,7 @@ Example on how to delete a record from DNS using 'nsupdate':
 
 # nsupdate
 > server 10.203.0.5
-> update delete oldhost.sddc.lab A
+> update delete oldhost.SDDC.Lab A
 > update delete 5.210.203.10.in-addr.arpa
 > send
 > quit


### PR DESCRIPTION
This PR contains structural changes to support NSX-T v3.2.0.   However, an issue still remains with the Edge Nodes where, under v3.2.0, they flop between SUCCESS and IN_PROGRESS states during the task of setting password aging to 0 (disable password expiration), and also generates a "Edge Datapath Mempool High" message indicating that the malloc_heap has reached 95%.  When the playbook to create the Edge Cluster is reached, the member EdgeVM Nodes are not all in "SUCCESS" state, and the play fails.  This may be caused by the fact that SMALL form factors are used.  Need to add a check to ensure all Edge Nodes are in a "SUCCESS" state, and if not, loop with a delay until they are.

Looking at memory usage during this event, the EdgeVM reports consuming 3.48GB of the 4GB that is provisioned.  See attached screenshots.   If you wait until all of the EdgeVMs settle down and reach "SUCCESS" state, then manually continue from the createNsxEdgeCluster.yml playbook, the deployment completes.

![image](https://user-images.githubusercontent.com/16770181/147402943-daa6242a-a5cf-4204-963c-6df9b15538ab.png)

![image](https://user-images.githubusercontent.com/16770181/147402947-019d1fcb-bc99-411c-bf36-cc8b3d241c1f.png)
