### PR TITLE
Configure UplinkProfile MTU value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -984,4 +984,7 @@
 
 ### Added by Luis Chanu
   - Added Tranpsort MTU to NSX-T Uplink Profile creation.
-  - Modified config_sample.yml to configure MTU value on UplinkProfiles dynamically, to the MTU that is set on the Transport (TEP) segment.
+  - Modified ```config_sample.yml``` to configure MTU value on UplinkProfiles dynamically, to the MTU that is set on the Transport (TEP) segment.
+  - Modified ```config_sample.yml```, playbooks, and templates, to allow Host Uplink Profile MTU to be empty, which is required for VDS v7 support.
+  - Removed MTU value from ```ESXi-Uplink-Profile``` within ```config_sample.yml``` file.
+  - As ```config_sample.yml``` was modified, please update your config files accordingly.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -979,3 +979,9 @@
   - Change permissions set within ```util_CreateSoftwareDir.yml``` from 775 to 777 to ensure non-root user can update the software repsoritory.
   - Modified ```util_CreateSoftwareDir.yml``` to set 777 permissions to top-level RootDirectory (/Software) directory as well.
   - Enabled ```deployWorkloadVMs.yml``` task in ```deploy.yml```.
+
+## Dev-v4.0.0 20-FEBRUARY-2022
+
+### Added by Luis Chanu
+  - Added Tranpsort MTU to NSX-T Uplink Profile creation.
+  - Modified config_sample.yml to configure MTU value on UplinkProfiles dynamically, to the MTU that is set on the Transport (TEP) segment.

--- a/README.md
+++ b/README.md
@@ -323,9 +323,10 @@ As we use SDDC.Lab in our labs, every now-and-then we notice some issues/problem
 
 | Date | vCenter Server | ESXi    |  NSX-T  | Description Of Issue | Documented By |
 |------|----------------|---------|---------|----------------------|---------------|
-| 5-JAN-2022 | 7.0.0U3        | 7.00U2A |         | Migrating vDS Uplinks in createVds playbook fails.  Deployed fine in ESXi v7.00U3. | Luis Chanu |
-| 5-JAN-2022 |                |         |  3.2.0  | NSX-T Federation deployment not supported. | Luis Chanu |
-| 31-JAN-2022 |                |         |  3.2.0.1  | NSX-T Federation deployment not supported. | Luis Chanu |
+| 5-JAN-2022 | 7.0.0U3  | 7.00U2A |         | Migrating vDS Uplinks in createVds playbook fails.  Deployed fine in ESXi v7.00U3. | Luis Chanu |
+| 5-JAN-2022 |          |         |  3.2.0  | NSX-T Federation deployment not supported. | Luis Chanu |
+| 31-JAN-2022 |         |         |  3.2.0.1  | NSX-T Federation deployment not supported. | Luis Chanu |
+| 20-FEB-2022 |         |         |  3.2.0.1  | NSX-T Global MTU Settings are not properly set. | Luis Chanu |
 
 
 ## More Information

--- a/config_sample.yml
+++ b/config_sample.yml
@@ -2324,7 +2324,7 @@ Nested_NSXT:
             Description: ESXi Host Transport Node Uplink Profile
             Transport:
               VLAN: "{{ Net.Transport.VLAN }}"
-              MTU: "{{ Net.Transport.MTU }}"
+              MTU:                                                                              # Leave MTU value empty if uplink is for ESXi hosts using VDS in Transport Node Profiles (TNP), as MTU is defined on the VDS within vCenter.  If not ESXi, use "{{ Net.Transport.MTU }}"
             DefaultTeaming:
               Policy: LOADBALANCE_SRCID                                                         # Options: LOADBALANCE_SRCID, FAILOVER_ORDER
               ActiveUplinks:
@@ -2336,7 +2336,7 @@ Nested_NSXT:
             Description: Edge Transport Node Uplink Profile
             Transport:
               VLAN: "{{ Net.Transport.VLAN }}"
-              MTU: "{{ Net.Transport.MTU }}"
+              MTU: "{{ Net.Transport.MTU }}"                                                    # Leave MTU value empty if uplink is for ESXi hosts using VDS in Transport Node Profiles (TNP), as MTU is defined on the VDS within vCenter.  If not ESXi, use "{{ Net.Transport.MTU }}"
             DefaultTeaming:
               Policy: LOADBALANCE_SRCID                                                         # Options: LOADBALANCE_SRCID, FAILOVER_ORDER
               ActiveUplinks:
@@ -2359,7 +2359,7 @@ Nested_NSXT:
             Description: Sample Uplink Profile
             Transport:
               VLAN: "{{ Net.Transport.VLAN }}"
-              MTU: "{{ Net.Transport.MTU }}"
+              MTU: "{{ Net.Transport.MTU }}"                                                    # Leave MTU value empty if uplink is for ESXi hosts using VDS in Transport Node Profiles (TNP), as MTU is defined on the VDS within vCenter.  If not ESXi, use "{{ Net.Transport.MTU }}"
             DefaultTeaming:
               Policy: LOADBALANCE_SRCID                                                         # Options: LOADBALANCE_SRCID, FAILOVER_ORDER
               ActiveUplinks:

--- a/config_sample.yml
+++ b/config_sample.yml
@@ -2324,7 +2324,7 @@ Nested_NSXT:
             Description: ESXi Host Transport Node Uplink Profile
             Transport:
               VLAN: "{{ Net.Transport.VLAN }}"
-              MTU:  9000
+              MTU: "{{ Net.Transport.MTU }}"
             DefaultTeaming:
               Policy: LOADBALANCE_SRCID                                                         # Options: LOADBALANCE_SRCID, FAILOVER_ORDER
               ActiveUplinks:
@@ -2336,7 +2336,7 @@ Nested_NSXT:
             Description: Edge Transport Node Uplink Profile
             Transport:
               VLAN: "{{ Net.Transport.VLAN }}"
-              MTU:  9000
+              MTU: "{{ Net.Transport.MTU }}"
             DefaultTeaming:
               Policy: LOADBALANCE_SRCID                                                         # Options: LOADBALANCE_SRCID, FAILOVER_ORDER
               ActiveUplinks:
@@ -2359,7 +2359,7 @@ Nested_NSXT:
             Description: Sample Uplink Profile
             Transport:
               VLAN: "{{ Net.Transport.VLAN }}"
-              MTU:  9000
+              MTU: "{{ Net.Transport.MTU }}"
             DefaultTeaming:
               Policy: LOADBALANCE_SRCID                                                         # Options: LOADBALANCE_SRCID, FAILOVER_ORDER
               ActiveUplinks:

--- a/playbooks/createNsxUplinkProfiles.yml
+++ b/playbooks/createNsxUplinkProfiles.yml
@@ -95,9 +95,9 @@
         display_name: "{{ item.display_name }}"
         description: "{{ item.description }}"                              # Description
         transport_vlan: "{{ item.transport_vlan }}"                        # Overlay Transport VLAN
-        mtu: "{{ item.mtu }}"                                              # MTU
+        mtu: "{{ item.mtu | default(omit) }}"                              # MTU, but omit if it does not exist - Needed to support VDS v7.0
         teaming: "{{ item.teaming }}"                                      # Default NIC Teaming
-        named_teamings: "{{ item.named_teamings | default(omit) }}"        # Named Teaming Policy, but omit it if it does not exist
+        named_teamings: "{{ item.named_teamings | default(omit) }}"        # Named Teaming Policy, but omit if it does not exist
         state: "present"
       with_list: "{{ UplinkProfilesToCreate }}"
       when:

--- a/playbooks/createNsxUplinkProfiles.yml
+++ b/playbooks/createNsxUplinkProfiles.yml
@@ -95,6 +95,7 @@
         display_name: "{{ item.display_name }}"
         description: "{{ item.description }}"                              # Description
         transport_vlan: "{{ item.transport_vlan }}"                        # Overlay Transport VLAN
+        mtu: "{{ item.mtu }}"                                              # MTU
         teaming: "{{ item.teaming }}"                                      # Default NIC Teaming
         named_teamings: "{{ item.named_teamings | default(omit) }}"        # Named Teaming Policy, but omit it if it does not exist
         state: "present"

--- a/templates/vars_NSXT_UplinkProfiles.j2
+++ b/templates/vars_NSXT_UplinkProfiles.j2
@@ -9,7 +9,10 @@
   - display_name:  "{{ UplinkProfile.Name }}"
     description:   "{{ UplinkProfile.Description }}"
     transport_vlan: {{ UplinkProfile.Transport.VLAN }}
+{# Only include MTU if it has been assigned a value #}
+{% if UplinkProfile.Transport.MTU %}
     mtu: {{ UplinkProfile.Transport.MTU }}
+{% endif %}{# UplinkProfile.Transport.MTU #}
 {############# Default Teaming Policy #############}
     teaming:
       policy: "{{ UplinkProfile.DefaultTeaming.Policy }}"

--- a/templates/vars_NSXT_UplinkProfiles.j2
+++ b/templates/vars_NSXT_UplinkProfiles.j2
@@ -9,6 +9,7 @@
   - display_name:  "{{ UplinkProfile.Name }}"
     description:   "{{ UplinkProfile.Description }}"
     transport_vlan: {{ UplinkProfile.Transport.VLAN }}
+    mtu: {{ UplinkProfile.Transport.MTU }}
 {############# Default Teaming Policy #############}
     teaming:
       policy: "{{ UplinkProfile.DefaultTeaming.Policy }}"


### PR DESCRIPTION
Unit testing of specific UplinkProfile playbook works fine.  Have not yet performed a full deployment.  Working on that now.

Uplink profiles in configuration file converted to use MTU value from Net.Transport.MTU rather than statically set within Nested_NSXT structure.