### PR TITLE
Request to merge 7zip branch with dev-v5 branch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1090,3 +1090,10 @@
   - Added network policy parameters (forged_transmits, mac_changes, promiscuous) to the vmware_dvs_portgroups task in ```createVds.yml```. Network policy configuration is stored in the Nested_vCenter dictionary in ```config_sample.yml```.
   - The parameters num_ports and port_binding used by the vmware_dvs_portgroups task in ```createVds.yml``` now fetch their values from the Nested_vCenter dictionary in ```config_sample.yml``` (instead of having them hard-coded in the Playbook).
   - Please be sure to update your ```config.yml``` file
+
+## Dev-v5.0.0 21-APRIL-2022
+
+### Added by Rutger Blom
+  - Replaced the ```ansible.posix.mount``` task in the ```playbooks/prepareISOInstaller.yml```playbook with a ```ansible.builtin.command```task running ```7z``` to extract the contents of the ESXi ISO file. The ```ansible.posix.mount``` task requires root or CAP_SYS_ADMIN privileges which is something we want to eliminate in the upcoming version.
+  - Added a new variable to the ```TargetConfig``` dictionary in ```config_sample.yml``` called ```ISOExtract```which is used by the ```playbooks/prepareISOInstaller.yml```playbook
+  - Please be sure to update your ```config.yml``` file

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1096,4 +1096,5 @@
 ### Added by Rutger Blom
   - Replaced the ```ansible.posix.mount``` task in the ```playbooks/prepareISOInstaller.yml```playbook with a ```ansible.builtin.command```task running ```7z``` to extract the contents of the ESXi ISO file. The ```ansible.posix.mount``` task requires root or CAP_SYS_ADMIN privileges which is something we want to eliminate in the upcoming version.
   - Added a new variable to the ```TargetConfig``` dictionary in ```config_sample.yml``` called ```ISOExtract```which is used by the ```playbooks/prepareISOInstaller.yml```playbook
+  - The 7Zip software package is now required so updated the ```README.md```with this requirement. 
   - Please be sure to update your ```config.yml``` file

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ The following are recommendations based on our experience with deploying Pods:
   * Add the Pod VLANs to your layer-3 switch in case you are deploying the Pod to a vSphere cluster. 
 
 * Install the required software on your Ansible controller:
-  * ```sudo apt install python3 python3-pip xorriso git```
+  * ```sudo apt install python3 python3-pip xorriso git p7zip-full```
   * ```sudo pip3 install --upgrade ansible pyvim pyvmomi netaddr jmespath dnspython paramiko setuptools testresources cryptography git+https://github.com/vmware/vsphere-automation-sdk-python.git```
   * ```git clone https://github.com/rutgerblom/SDDC.Lab.git``` 
   * ```ansible-galaxy collection install -r SDDC.Lab/requirements.yml```

--- a/config_sample.yml
+++ b/config_sample.yml
@@ -236,6 +236,7 @@ TargetConfig:
     VMFolder: ha-datacenter/vm
     ISOFolder: /SDDCLab-ISO-Folder
     ISOMount:   "/media"                                                      # ISOMount - Base mount point directory for ISO images
+    ISOExtract: "{{ lookup('env','HOME') }}"                                  # ISOExtract - Base extraction point directory for ISO images
     TempFolder: "/tmp/{{ SiteCode }}"
     TemplateFolder: ../templates
     PortGroup:
@@ -258,6 +259,7 @@ TargetConfig:
     VMFolder: "SDDC Pods/{{ SiteCode }}"                                      # VMFolder - Deployed lab Pod VMs are placed within this VMFolder
     ISOFolder: /SDDCLab-ISO-Folder                                            # ISOFolder - Directory created within Datastore where custom created ISOs are placed as part of the nested lab deployment
     ISOMount:   "/media"                                                      # ISOMount - Base mount point directory for ISO images
+    ISOExtract: "{{ lookup('env','HOME') }}"                                  # ISOExtract - Base extraction point directory for ISO images
     TempFolder: "/tmp/{{ SiteCode }}"                                         # TempFolder - Temporary folder location used for temporary files created during the deployment process
     TemplateFolder: ../templates                                              # TemplateFolder - The location of the "templates" folder, relative to teh "playbooks" directory
     PortGroup:                                                                # Various PortGroups used during deployment
@@ -296,6 +298,7 @@ Target:
   VMFolder:       "{{ TargetConfig[TargetConfig.Deployment].VMFolder }}"
   ISOFolder:      "{{ TargetConfig[TargetConfig.Deployment].ISOFolder }}"
   ISOMount:       "{{ TargetConfig[TargetConfig.Deployment].ISOMount }}"
+  ISOExtract:     "{{ TargetConfig[TargetConfig.Deployment].ISOExtract }}"
   TempFolder:     "{{ TargetConfig[TargetConfig.Deployment].TempFolder }}"
   TemplateFolder: "{{ TargetConfig[TargetConfig.Deployment].TemplateFolder }}"
   PortGroup:

--- a/playbooks/prepareISOInstaller.yml
+++ b/playbooks/prepareISOInstaller.yml
@@ -88,19 +88,19 @@
 #      tags: esxi-install-media
 
     - name: Extract ESXi ISO
-      ansible.builtin.command: "7z x {{ Deploy.Software.ESXi.Directory }}/{{ Deploy.Software.ESXi.File }} -o{{ ISOExtractPoint }}"
+      ansible.builtin.command: "7z x {{ Deploy.Software.ESXi.Directory }}/{{ Deploy.Software.ESXi.File }} -o{{ ISOExtractPoint }} -y"
 
 
     - name: Copy boot.cfg from the ESXi ISOExtractPoint
       ansible.builtin.copy: 
-        src: "{{ ISOExtractPoint }}/boot.cfg"
+        src: "{{ ISOExtractPoint }}/BOOT.CFG"
         dest: "{{ Target.TempFolder }}/{{ Deploy.Software.ESXi.Installer }}/"
         mode: "666"
       tags: esxi-install-media
 
     - name: Edit boot.cfg
       ansible.builtin.replace:
-        dest: "{{ Target.TempFolder }}/{{ Deploy.Software.ESXi.Installer }}/boot.cfg"
+        dest: "{{ Target.TempFolder }}/{{ Deploy.Software.ESXi.Installer }}/BOOT.CFG"
         regexp: 'kernelopt=.*'
         replace: 'kernelopt=ks=cdrom:/{{ Deploy.Software.ESXi.Config }}'
       tags: esxi-install-media
@@ -123,7 +123,7 @@
       tags: esxi-install-media
 
     - name: Create custom ESXi ISO for each nested ESXi host
-      ansible.builtin.command: "xorrisofs -relaxed-filenames -J -R -o {{ Target.TempFolder }}/{{ Pod.Number }}{{ item.key }} -b isolinux.bin -c boot.cat -no-emul-boot -boot-load-size 4 -boot-info-table {{ ISOExtractPoint }}/ {{ Target.TempFolder }}/{{ Deploy.Software.ESXi.Installer }}/ {{ Target.TempFolder }}/{{ item.value.VMName }}/{{ Deploy.Software.ESXi.Config }}"
+      ansible.builtin.command: "xorrisofs -relaxed-filenames -J -R -o {{ Target.TempFolder }}/{{ Pod.Number }}{{ item.key }} -b ISOLINUX.BIN -c BOOT.CAT -no-emul-boot -boot-load-size 4 -boot-info-table {{ ISOExtractPoint }}/ {{ Target.TempFolder }}/{{ Deploy.Software.ESXi.Installer }}/ {{ Target.TempFolder }}/{{ item.value.VMName }}/{{ Deploy.Software.ESXi.Config }}"
       args:
         chdir: "{{ Target.TempFolder }}/{{ item.value.VMName }}/"
       loop: "{{ Nested_ESXi.Host | dict2items }}"

--- a/playbooks/prepareISOInstaller.yml
+++ b/playbooks/prepareISOInstaller.yml
@@ -7,7 +7,8 @@
 - hosts: localhost
   name: prepareISOInstaller.yml
   vars:
-    ISOMountPoint: "{{ Target.ISOMount }}/{{ Deploy.Software.ESXi.Vendor }}_{{ Deploy.Software.ESXi.Product }}_{{ Deploy.Software.ESXi.Version }}"
+    #ISOMountPoint: "{{ Target.ISOMount }}/{{ Deploy.Software.ESXi.Vendor }}_{{ Deploy.Software.ESXi.Product }}_{{ Deploy.Software.ESXi.Version }}"
+    ISOExtractPoint: "{{ Target.ISOExtract }}/{{ Deploy.Software.ESXi.Vendor }}_{{ Deploy.Software.ESXi.Product }}_{{ Deploy.Software.ESXi.Version }}"
   tasks:
     - name: prepareISOInstaller_Playbook
       ansible.builtin.debug:
@@ -63,7 +64,7 @@
                                      Target.ISOFolder: {{ Target.ISOFolder }}
                                     Target.TempFolder: {{ Target.TempFolder }}
 
-                                        ISOMountPoint: {{ ISOMountPoint }}
+                                        ISOExtractPoint: {{ ISOExtractPoint }}
 
                          Deploy.Software.ESXi.Version: {{ Deploy.Software.ESXi.Version }}
                        Deploy.Software.ESXi.Installer: {{ Deploy.Software.ESXi.Installer }}
@@ -77,18 +78,22 @@
         path: "{{ Target.TempFolder }}"
         state: directory
 
-    - name: Mount ESXi ISO as read-only and do not automatically mount with 'mount -a'
-      ansible.posix.mount:
-        path:   "{{ ISOMountPoint }}"
-        src:    "{{ Deploy.Software.ESXi.Directory }}/{{ Deploy.Software.ESXi.File }}"
-        fstype: iso9660
-        opts:   ro,noauto
-        state:  mounted
-      tags: esxi-install-media
+#    - name: Mount ESXi ISO as read-only and do not automatically mount with 'mount -a'
+#      ansible.posix.mount:
+#        path:   "{{ ISOMountPoint }}"
+#        src:    "{{ Deploy.Software.ESXi.Directory }}/{{ Deploy.Software.ESXi.File }}"
+#        fstype: iso9660
+#        opts:   ro,noauto
+#        state:  mounted
+#      tags: esxi-install-media
 
-    - name: Copy boot.cfg from the ESXi ISO
+    - name: Extract ESXi ISO
+      ansible.builtin.command: "7z x {{ Deploy.Software.ESXi.Directory }}/{{ Deploy.Software.ESXi.File }} -o{{ ISOExtractPoint }}"
+
+
+    - name: Copy boot.cfg from the ESXi ISOExtractPoint
       ansible.builtin.copy: 
-        src: "{{ ISOMountPoint }}/boot.cfg"
+        src: "{{ ISOExtractPoint }}/boot.cfg"
         dest: "{{ Target.TempFolder }}/{{ Deploy.Software.ESXi.Installer }}/"
         mode: "666"
       tags: esxi-install-media
@@ -118,19 +123,19 @@
       tags: esxi-install-media
 
     - name: Create custom ESXi ISO for each nested ESXi host
-      ansible.builtin.command: "xorrisofs -relaxed-filenames -J -R -o {{ Target.TempFolder }}/{{ Pod.Number }}{{ item.key }} -b isolinux.bin -c boot.cat -no-emul-boot -boot-load-size 4 -boot-info-table {{ ISOMountPoint }}/ {{ Target.TempFolder }}/{{ Deploy.Software.ESXi.Installer }}/ {{ Target.TempFolder }}/{{ item.value.VMName }}/{{ Deploy.Software.ESXi.Config }}"
+      ansible.builtin.command: "xorrisofs -relaxed-filenames -J -R -o {{ Target.TempFolder }}/{{ Pod.Number }}{{ item.key }} -b isolinux.bin -c boot.cat -no-emul-boot -boot-load-size 4 -boot-info-table {{ ISOExtractPoint }}/ {{ Target.TempFolder }}/{{ Deploy.Software.ESXi.Installer }}/ {{ Target.TempFolder }}/{{ item.value.VMName }}/{{ Deploy.Software.ESXi.Config }}"
       args:
         chdir: "{{ Target.TempFolder }}/{{ item.value.VMName }}/"
       loop: "{{ Nested_ESXi.Host | dict2items }}"
       when: Nested_Cluster[item.value.Cluster]['DeployHosts'] == true
       tags: esxi-install-media
 
-    - name: Unmount ESXi ISO
-      ansible.posix.mount:
-        path:  "{{ ISOMountPoint }}"
-        state: absent
-      when: Deploy.Software.Options.UnmountISO
-      tags: esxi-install-media
+    #- name: Unmount ESXi ISO
+    #  ansible.posix.mount:
+    #    path:  "{{ ISOMountPoint }}"
+    #    state: absent
+    #  when: Deploy.Software.Options.UnmountISO
+    #  tags: esxi-install-media
 
     - name: Upload the ESXi ISO to the datastore
       community.vmware.vsphere_copy: 


### PR DESCRIPTION
  - Replaced the ```ansible.posix.mount``` task in the ```playbooks/prepareISOInstaller.yml``` playbook with a ```ansible.builtin.command``` task running ```7z``` to extract the contents of the ESXi ISO file. The ```ansible.posix.mount``` task requires root or CAP_SYS_ADMIN privileges which is something we want to eliminate in the upcoming version.
  - Added a new variable to the ```TargetConfig``` dictionary in ```config_sample.yml``` called ```ISOExtract```which is used by the ```playbooks/prepareISOInstaller.yml```playbook
  - The 7Zip software package is now required so updated the ```README.md```with this requirement. 
  - Please be sure to update your ```config.yml``` file