### PR TITLE
Add 'ignore_errors: true" to port-group deletion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1213,3 +1213,4 @@
 ### Added by Luis Chanu
   - Removed extra spaces from Nested_Cluster section of ```config_sample.yml``` file.
   - Noticed an issue where if more than 1 vSphere Cluster was configured to be prepared by NSX, only one vSphere cluster would end up being prepared.  Corrected the issue by making the transport node collection display name be unique for each cluster by including the cluster name in the TNC display name field within ```attchNsxTnp.yml```.
+  - Added "ignore_errors: true" to Port-Group removal plays in ```undeploy.yml``` file.

--- a/undeploy.yml
+++ b/undeploy.yml
@@ -209,6 +209,7 @@
           promiscuous: true
           forged_transmits: true
           mac_changes: false
+      ignore_errors: true
       when: Target.Deployment == "vCenter"
 
     - name: Remove a Trunk Distributed Port-Group in vCenter
@@ -228,6 +229,7 @@
           promiscuous: true
           forged_transmits: true
           mac_changes: false
+      ignore_errors: true
       when: Target.Deployment == "vCenter"
 
 ##


### PR DESCRIPTION
This is to address the situation where an error occurs during the undeploy of a Pod.