### PR TITLE
Added 'Util_GenerateDNSZoneFiles.yml'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2050,3 +2050,4 @@
 ### Added by Luis Chanu
   - Created ```utils/Util_GenerateDNSZoneFiles.yml`` to test and troubleshoot DNS Jinja2 templates.
   - Added ```templates/BIND_v9_db.reversezoneipv4_overlay.j2``` to provide Reverse DNS for IPv4 overlay network space.
+  - Added ```templates/BIND_v9_db.reversezoneipv6_overlay.j2``` to provide Reverse DNS for IPv6 overlay network space.  Note that the addres space used for IPv6 overlay is hard coded within this Jinja2 template.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2043,9 +2043,10 @@
 
 ### Added by Luis Chanu
   - Fixed type-O's in ```CHANGELOG.md``` file.
-  - Created ```utils\Util_AddIPv4DNSRecord.sh``` which simplifies the manual creation of a single IPv4 DNS record
+  - Created ```utils/Util_AddIPv4DNSRecord.sh``` which simplifies the manual creation of a single IPv4 DNS record
 
 ## Dev-v6.0.0 06-AUGUST-2023
 
 ### Added by Luis Chanu
-  - Created ```utils\Util_GenerateDNSZoneFiles.yml`` to test and troubleshoot DNS Jinja2 templates.
+  - Created ```utils/Util_GenerateDNSZoneFiles.yml`` to test and troubleshoot DNS Jinja2 templates.
+  - Added ```templates/BIND_v9_db.reversezoneipv4_overlay.j2``` to provide Reverse DNS for IPv4 overlay network space.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2044,3 +2044,8 @@
 ### Added by Luis Chanu
   - Fixed type-O's in ```CHANGELOG.md``` file.
   - Created ```utils\Util_AddIPv4DNSRecord.sh``` which simplifies the manual creation of a single IPv4 DNS record
+
+## Dev-v6.0.0 06-AUGUST-2023
+
+### Added by Luis Chanu
+  - Created ```utils\Util_GenerateDNSZoneFiles.yml`` to test and troubleshoot DNS Jinja2 templates.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2051,3 +2051,4 @@
   - Created ```utils/Util_GenerateDNSZoneFiles.yml`` to test and troubleshoot DNS Jinja2 templates.
   - Added ```templates/BIND_v9_db.reversezoneipv4_overlay.j2``` to provide Reverse DNS for IPv4 overlay network space.
   - Added ```templates/BIND_v9_db.reversezoneipv6_overlay.j2``` to provide Reverse DNS for IPv6 overlay network space.  Note that the addres space used for IPv6 overlay is hard coded within this Jinja2 template.
+  - Added vCenter v7.00 Update 3M to ```templates_sample.yml``` file.

--- a/templates/BIND_v9_db.reversezoneipv4_overlay.j2
+++ b/templates/BIND_v9_db.reversezoneipv4_overlay.j2
@@ -1,0 +1,20 @@
+$TTL 604800
+{{ Pod.BaseOverlay.IPv4.Network | ansible.utils.ipaddr('revdns') | regex_replace('^.{4}(.*)$', '\\1') }}  IN SOA dns.{{ Common.DNS.Domain | lower }}. admin.{{ Common.DNS.Domain | lower }}. (
+           1   ; Serial
+      604800   ; Refresh
+       86400   ; Retry
+     2419200   ; Expire
+      604800 ) ; Negative Cache TTL
+;
+
+; Name servers
+               NS   dns.{{ Common.DNS.Domain | lower }}.
+
+; A records for name servers
+dns            IN   A    {{ Nested_DNSServer.OS.Network.IPv4.Address }}
+
+;Define origin
+$ORIGIN {{ Pod.BaseOverlay.IPv4.Network | ansible.utils.ipaddr('revdns') | regex_replace('^.{4}(.*)$', '\\1') }}
+
+; PTR records
+{{ Nested_DNSServer.OS.Network.IPv4.Address | ansible.utils.ipaddr('revdns') | regex_replace('(^[0-9]+.[0-9]+)..+$', '\\1') }}    IN   PTR  dns.{{ Common.DNS.Domain | lower }}.

--- a/templates/BIND_v9_db.reversezoneipv6_overlay.j2
+++ b/templates/BIND_v9_db.reversezoneipv6_overlay.j2
@@ -1,0 +1,11 @@
+$TTL 604800     ; 1 week
+c.f.ip6.arpa.  IN SOA  dns.{{ Common.DNS.Domain | lower }}. admin.{{ Common.DNS.Domain | lower }}. (
+                1          ; serial
+                604800     ; refresh (1 week)
+                86400      ; retry (1 day)
+                2419200    ; expire (4 weeks)
+                604800     ; minimum (1 week)
+                )
+
+            IN    NS      dns.{{ Common.DNS.Domain | lower }}.
+$ORIGIN c.f.ip6.arpa.

--- a/templates_sample.yml
+++ b/templates_sample.yml
@@ -207,6 +207,12 @@ Template:
         Repl_ESXi:    vCenter_v7.0.0_embedded_vCSA_replication_on_ESXi.j2
         vCenter: vCenter_v7.0.0_embedded_vCSA_on_VC.j2
         ESXi:    vCenter_v7.0.0_embedded_vCSA_on_ESXi.j2
+    "7.00U3M":
+      Template:
+        Repl_vCenter: vCenter_v7.0.0_embedded_vCSA_replication_on_VC.j2
+        Repl_ESXi:    vCenter_v7.0.0_embedded_vCSA_replication_on_ESXi.j2
+        vCenter: vCenter_v7.0.0_embedded_vCSA_on_VC.j2
+        ESXi:    vCenter_v7.0.0_embedded_vCSA_on_ESXi.j2
     "8.00":
       Template:
         Repl_vCenter: vCenter_v8.0.0_embedded_vCSA_replication_on_VC.j2

--- a/utils/Util_GenerateDNSZoneFiles.yml
+++ b/utils/Util_GenerateDNSZoneFiles.yml
@@ -1,0 +1,27 @@
+##
+##    Project: SDDC.Lab
+##    Authors: Luis Chanu & Rutger Blom
+##   Filename: utils/Util_GenerateDNSZoneFiles.yml
+##
+##
+## This playbook utility applies the supplied configuration to a specified template(s), and writes the output to /tmp/ZoneFile_for_xxxxx.j2.
+## Although the output file ends in .j2, it is only to indicate which Jinja2 template was rendered, but it's contents contain the rendered output.
+##
+## The command syntax to run this script is the same as is used to deploy a SDDC Lab, except you execut this script.  That command looks like this:
+##
+##              ansible-playbook  -e "@~/Pod-XXX-Config.yml" utils/Util_GenerateDNSZoneFiles.yml
+##
+---
+- hosts: localhost
+  gather_facts: false
+  vars:
+    - Templates:
+      - BIND_v9_db.reversezoneipv4_overlay.j2
+
+  tasks:
+    - name: Generating DNS zone files from DNS templates
+      ansible.builtin.template: 
+        src:  "../templates/{{ item }}"
+        dest: "/tmp/ZoneFile_for_{{ item }}"
+        force: yes
+      loop: "{{ Templates }}"

--- a/utils/Util_GenerateDNSZoneFiles.yml
+++ b/utils/Util_GenerateDNSZoneFiles.yml
@@ -17,6 +17,7 @@
   vars:
     - Templates:
       - BIND_v9_db.reversezoneipv4_overlay.j2
+      - BIND_v9_db.reversezoneipv6_overlay.j2
 
   tasks:
     - name: Generating DNS zone files from DNS templates


### PR DESCRIPTION
Purpose of this utility is to provide an easy way to test/verify DNS Jinja2 templates are rendering as expected.  Edit the "Templates" variable within the playbook to indicate what DNS Template(s) to render.