### PR TITLE
Increased delays in DeployRouter playbook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2052,3 +2052,8 @@
   - Added ```templates/BIND_v9_db.reversezoneipv4_overlay.j2``` to provide Reverse DNS for IPv4 overlay network space.
   - Added ```templates/BIND_v9_db.reversezoneipv6_overlay.j2``` to provide Reverse DNS for IPv6 overlay network space.  Note that the addres space used for IPv6 overlay is hard coded within this Jinja2 template.
   - Added vCenter v7.00 Update 3M to ```templates_sample.yml``` file.
+
+## Dev-v6.0.0 07-AUGUST-2023
+
+### Added by Luis Chanu
+  - Increased delays from 5 seconds to 10 seconds in dialogs 4-7 of ```DeployRouter.yml``` playbook to accomodate busy servers with slow disk performance.

--- a/playbooks/DeployRouter.yml
+++ b/playbooks/DeployRouter.yml
@@ -298,9 +298,9 @@
         - Deploy.Product.Router.Deploy
         - status is failed
 
-    - name: Wait 5 seconds
+    - name: Wait 10 seconds
       ansible.builtin.pause:
-        seconds: 5
+        seconds: 10
       when:
         - Deploy.Product.Router.Deploy
         - status is failed
@@ -322,9 +322,9 @@
         - Deploy.Product.Router.Deploy
         - status is failed
 
-    - name: Wait 5 seconds
+    - name: Wait 10 seconds
       ansible.builtin.pause:
-        seconds: 5
+        seconds: 10
       when:
         - Deploy.Product.Router.Deploy
         - status is failed
@@ -346,9 +346,9 @@
         - Deploy.Product.Router.Deploy
         - status is failed
 
-    - name: Wait 5 seconds
+    - name: Wait 10 seconds
       ansible.builtin.pause:
-        seconds: 5
+        seconds: 10
       when:
         - Deploy.Product.Router.Deploy
         - status is failed
@@ -367,9 +367,9 @@
         - Deploy.Product.Router.Deploy
         - status is failed
 
-    - name: Wait 5 seconds
+    - name: Wait 10 seconds
       ansible.builtin.pause:
-        seconds: 5
+        seconds: 10
       when:
         - Deploy.Product.Router.Deploy
         - status is failed


### PR DESCRIPTION
To accommodate servers with slow disk performance, delay timers were increased from 5 to 10 seconds.