### PR TITLE
Netplan update, DNS protocol, VyOS move to github releases

### DIFF
--- a/config_sample.yml
+++ b/config_sample.yml
@@ -184,9 +184,12 @@ Common:
     LeaseTime: 3600                                                           # DHCP Lease Time (in seconds) for Overlay Segments
   DNS:
     Domain: SDDC.Lab                                                          # Domain - Default DNS Domain used by all nested components.
+    ForwarderIPv4: 8.8.8.8                                                    # Forwarder - Default DNS forwarding address used by nested routers.
+    ForwarderIPv6: 2001:4860:4860::8888                                       # Forwarderv6 - Default DNS IPv6 forwarding address used by nested routers.    
     Server1:
       IPv4: "{{ Net.Uplink.IPv4.Network }}.5"                                 # Replace this IP if using a different DNS server than the suggested .5  server in the Router Uplink segment (MUST support Dynamic DNS Updates)
       IPv6: "{{ Net.Uplink.IPv6.Network }}::{{ '%04x'|format(5) }}"           # Replace this IP if using a different DNS server than the suggested ::5 server in the Router Uplink segment (MUST support Dynamic DNS Updates)
+      Protocol: udp                                                           # Select protocol to be used when adding/updating dns records for pods on the nested DNS server
     Server2:
       IPv4: 
       IPv6: 
@@ -850,11 +853,11 @@ Nested_DNSServer:
         Address: "{{ Net.Uplink.IPv4.Network }}.5" 
         Prefix:  "{{ Net.Uplink.IPv4.Prefix }}"
         Gateway: "{{ Net.Uplink.IPv4.Network }}.1"
-        DNS: 8.8.8.8                                                                    # DNS server reachable by OS to resolve names.  Update as required for your environment.
+        DNS: "{{ Common.DNS.ForwarderIPv4 }}"                                                                   # DNS server reachable by OS to resolve names.  Update as required for your environment.
       IPv6:
         Address: "{{ Net.Uplink.IPv6.Network }}::{{ '%04x'|format(5) }}" 
         Prefix:  "{{ Net.Uplink.IPv6.Prefix }}"
-        DNS: 2001:4860:4860::8888
+        DNS: "{{ Common.DNS.ForwarderIPv6 }}"
     Locale: en_US
     Keyboard:
       Layout: us
@@ -862,8 +865,8 @@ Nested_DNSServer:
     Packages:
       BIND:
         Forwarder:
-          IPv4: 8.8.8.8                                                                 # DNS forwarders used by BIND.  Update as required for your environment.
-          IPv6: 2001:4860:4860::8888
+          IPv4: "{{ Common.DNS.ForwarderIPv4 }}"                                                                 # DNS forwarders used by BIND.  Update as required for your environment.
+          IPv6: "{{ Common.DNS.ForwarderIPv6 }}"
 
 
 

--- a/playbooks/DeployRouter.yml
+++ b/playbooks/DeployRouter.yml
@@ -128,7 +128,7 @@
 
     - name: Download VyOS installation media (overwrite if exists)
       ansible.builtin.get_url:
-        url: "{{ Deploy.Software.Router.URL }}/{{ Deploy.Software.Router.File }}"
+        url: "{{ Deploy.Software.Router.URL }}"
         dest: "{{ Target.TempFolder }}/{{ Deploy.Software.Router.Installer }}"
         force: true
         mode: "755"

--- a/playbooks/UpdateDNS.yml
+++ b/playbooks/UpdateDNS.yml
@@ -89,6 +89,7 @@
                                     Common.DNS.Domain: {{ Common.DNS.Domain }}
                               Common.DNS.Server1.IPv4: {{ Common.DNS.Server1.IPv4 }}
                               Common.DNS.Server1.IPv6: {{ Common.DNS.Server1.IPv6 }}
+                              Common.DNS.Server1.Protocol: {{ Common.DNS.Server1.Protocol }}
 
                                  Pod.BaseNetwork.IPv4: {{ Pod.BaseNetwork.IPv4 }}
                                  Pod.BaseNetwork.IPv6: {{ Pod.BaseNetwork.IPv6 }}

--- a/playbooks/UpdateDNS.yml
+++ b/playbooks/UpdateDNS.yml
@@ -145,7 +145,7 @@
       community.general.nsupdate:
         server: "{{ Common.DNS.Server1.IPv4 }}"
         type: A
-        protocol: udp
+        protocol: "{{ Common.DNS.Server1.Protocol }}"
         zone: "{{ Common.DNS.Domain }}"
         record: "{{ Nested_Router.Name }}-{{ item.key }}"
         value: "{{ item.value.IPv4.Address }}"
@@ -159,7 +159,7 @@
       community.general.nsupdate:
         server: "{{ Common.DNS.Server1.IPv4 }}"
         type: CNAME
-        protocol: udp
+        protocol: "{{ Common.DNS.Server1.Protocol }}"
         zone: "{{ Common.DNS.Domain }}"
         record: "{{ Nested_Router.Name }}"
         value: "{{ Nested_Router.Name }}-Uplink"
@@ -194,7 +194,7 @@
       community.general.nsupdate:
         server: "{{ Common.DNS.Server1.IPv4 }}"
         type: PTR
-        protocol: udp
+        protocol: "{{ Common.DNS.Server1.Protocol }}"
         zone: "{{ ipv4_reverse_zone }}"
         record: "{{ item.value.IPv4.Address | ansible.utils.ipaddr('revdns') }}"
         value: "{{ Nested_Router.Name }}-{{ item.key }}.{{ Common.DNS.Domain }}."
@@ -238,7 +238,7 @@
       community.general.nsupdate:
         server: "{{ Common.DNS.Server1.IPv6 }}"
         type: AAAA
-        protocol: udp
+        protocol: "{{ Common.DNS.Server1.Protocol }}"
         zone: "{{ Common.DNS.Domain }}"
         record: "{{ Nested_Router.Name }}-{{ item.key }}"
         value: "{{ item.value.IPv6.Address }}"
@@ -274,7 +274,7 @@
       community.general.nsupdate:
         server: "{{ Common.DNS.Server1.IPv6 }}"
         type: PTR
-        protocol: udp
+        protocol: "{{ Common.DNS.Server1.Protocol }}"
         zone: "{{ ipv6_reverse_zone }}"
         record: "{{ item.value.IPv6.Address | ansible.utils.ipaddr('revdns') }}"
         value: "{{ Nested_Router.Name }}-{{ item.key }}.{{ Common.DNS.Domain }}."
@@ -329,7 +329,7 @@
       community.general.nsupdate:
         server: "{{ Common.DNS.Server1.IPv4 }}"
         type: A
-        protocol: udp
+        protocol: "{{ Common.DNS.Server1.Protocol }}"
         zone: "{{ Common.DNS.Domain }}"
         record: "{{ item.value.VMName }}"
         value: "{{ item.value.Address.IPv4.Address }}"
@@ -365,7 +365,7 @@
       community.general.nsupdate:
         server: "{{ Common.DNS.Server1.IPv4 }}"
         type: PTR
-        protocol: udp
+        protocol: "{{ Common.DNS.Server1.Protocol }}"
         zone: "{{ ipv4_reverse_zone }}"
         record: "{{ item.value.Address.IPv4.Address | ansible.utils.ipaddr('revdns') }}"
         value: "{{ item.value.VMName }}.{{ Common.DNS.Domain }}."
@@ -409,7 +409,7 @@
       community.general.nsupdate:
         server: "{{ Common.DNS.Server1.IPv6 }}"
         type: AAAA
-        protocol: udp
+        protocol: "{{ Common.DNS.Server1.Protocol }}"
         zone: "{{ Common.DNS.Domain }}"
         record: "{{ item.value.VMName }}"
         value: "{{ item.value.Address.IPv6.Address }}"
@@ -445,7 +445,7 @@
       community.general.nsupdate:
         server: "{{ Common.DNS.Server1.IPv6 }}"
         type: PTR
-        protocol: udp
+        protocol: "{{ Common.DNS.Server1.Protocol }}"
         zone: "{{ ipv6_reverse_zone }}"
         record: "{{ item.value.Address.IPv6.Address | ansible.utils.ipaddr('revdns') }}"
         value: "{{ item.value.VMName }}.{{ Common.DNS.Domain }}."
@@ -500,7 +500,7 @@
       community.general.nsupdate:
         server: "{{ Common.DNS.Server1.IPv4 }}"
         type: A
-        protocol: udp
+        protocol: "{{ Common.DNS.Server1.Protocol }}"
         zone: "{{ Common.DNS.Domain }}"
         record: "{{ item.value.VMName }}"
         value: "{{ item.value.Address.IPv4.Address }}"
@@ -536,7 +536,7 @@
       community.general.nsupdate:
         server: "{{ Common.DNS.Server1.IPv4 }}"
         type: PTR
-        protocol: udp
+        protocol: "{{ Common.DNS.Server1.Protocol }}"
         zone: "{{ ipv4_reverse_zone }}"
         record: "{{ item.value.Address.IPv4.Address | ansible.utils.ipaddr('revdns') }}"
         value: "{{ item.value.VMName }}.{{ Common.DNS.Domain }}."
@@ -581,7 +581,7 @@
       community.general.nsupdate:
         server: "{{ Common.DNS.Server1.IPv6 }}"
         type: AAAA
-        protocol: udp
+        protocol: "{{ Common.DNS.Server1.Protocol }}"
         zone: "{{ Common.DNS.Domain }}"
         record: "{{ item.value.VMName }}"
         value: "{{ item.value.Address.IPv6.Address }}"
@@ -619,7 +619,7 @@
       community.general.nsupdate:
         server: "{{ Common.DNS.Server1.IPv6 }}"
         type: PTR
-        protocol: udp
+        protocol: "{{ Common.DNS.Server1.Protocol }}"
         zone: "{{ ipv6_reverse_zone }}"
         record: "{{ item.value.Address.IPv6.Address | ansible.utils.ipaddr('revdns') }}"
         value: "{{ item.value.VMName }}.{{ Common.DNS.Domain }}."
@@ -675,7 +675,7 @@
       community.general.nsupdate:
         server: "{{ Common.DNS.Server1.IPv4 }}"
         type: A
-        protocol: udp
+        protocol: "{{ Common.DNS.Server1.Protocol }}"
         zone: "{{ Common.DNS.Domain }}"
         record: "{{ item.value.VMName }}"
         value: "{{ item.value.Address.IPv4.Address }}"
@@ -711,7 +711,7 @@
       community.general.nsupdate:
         server: "{{ Common.DNS.Server1.IPv4 }}"
         type: PTR
-        protocol: udp
+        protocol: "{{ Common.DNS.Server1.Protocol }}"
         zone: "{{ ipv4_reverse_zone }}"
         record: "{{ item.value.Address.IPv4.Address | ansible.utils.ipaddr('revdns') }}"
         value: "{{ item.value.VMName }}.{{ Common.DNS.Domain }}."
@@ -755,7 +755,7 @@
       community.general.nsupdate:
         server: "{{ Common.DNS.Server1.IPv6 }}"
         type: AAAA
-        protocol: udp
+        protocol: "{{ Common.DNS.Server1.Protocol }}"
         zone: "{{ Common.DNS.Domain }}"
         record: "{{ item.value.VMName }}"
         value: "{{ item.value.Address.IPv6.Address }}"
@@ -791,7 +791,7 @@
       community.general.nsupdate:
         server: "{{ Common.DNS.Server1.IPv6 }}"
         type: PTR
-        protocol: udp
+        protocol: "{{ Common.DNS.Server1.Protocol }}"
         zone: "{{ ipv6_reverse_zone }}"
         record: "{{ item.value.Address.IPv6.Address | ansible.utils.ipaddr('revdns') }}"
         value: "{{ item.value.VMName }}.{{ Common.DNS.Domain }}."
@@ -846,7 +846,7 @@
       community.general.nsupdate:
         server: "{{ Common.DNS.Server1.IPv4 }}"
         type: A
-        protocol: udp
+        protocol: "{{ Common.DNS.Server1.Protocol }}"
         zone: "{{ Common.DNS.Domain }}"
         record: "{{ item.value.VMName }}"
         value: "{{ item.value.vmk.vmk0.Address.IPv4.Address }}"
@@ -882,7 +882,7 @@
       community.general.nsupdate:
         server: "{{ Common.DNS.Server1.IPv4 }}"
         type: PTR
-        protocol: udp
+        protocol: "{{ Common.DNS.Server1.Protocol }}"
         zone: "{{ ipv4_reverse_zone }}"
         record: "{{ item.value.vmk.vmk0.Address.IPv4.Address | ansible.utils.ipaddr('revdns') }}"
         value: "{{ item.value.VMName }}.{{ Common.DNS.Domain }}."
@@ -927,7 +927,7 @@
       community.general.nsupdate:
         server: "{{ Common.DNS.Server1.IPv6 }}"
         type: AAAA
-        protocol: udp
+        protocol: "{{ Common.DNS.Server1.Protocol }}"
         zone: "{{ Common.DNS.Domain }}"
         record: "{{ item.value.VMName }}"
         value: "{{ item.value.vmk.vmk0.Address.IPv6.Address }}"
@@ -965,7 +965,7 @@
       community.general.nsupdate:
         server: "{{ Common.DNS.Server1.IPv6 }}"
         type: PTR
-        protocol: udp
+        protocol: "{{ Common.DNS.Server1.Protocol }}"
         zone: "{{ ipv6_reverse_zone }}"
         record: "{{ item.value.vmk.vmk0.Address.IPv6.Address | ansible.utils.ipaddr('revdns') }}"
         value: "{{ item.value.VMName }}.{{ Common.DNS.Domain }}."
@@ -1020,7 +1020,7 @@
       community.general.nsupdate:
         server: "{{ Common.DNS.Server1.IPv4 }}"
         type: A
-        protocol: udp
+        protocol: "{{ Common.DNS.Server1.Protocol }}"
         zone: "{{ Common.DNS.Domain }}"
         record: "{{ Nested_vCenter.VMName }}"
         value: "{{ Nested_vCenter.Address.IPv4.Address }}"
@@ -1054,7 +1054,7 @@
       community.general.nsupdate:
         server: "{{ Common.DNS.Server1.IPv4 }}"
         type: PTR
-        protocol: udp
+        protocol: "{{ Common.DNS.Server1.Protocol }}"
         zone: "{{ ipv4_reverse_zone }}"
         record: "{{ Nested_vCenter.Address.IPv4.Address | ansible.utils.ipaddr('revdns') }}"
         value: "{{ Nested_vCenter.VMName }}.{{ Common.DNS.Domain }}."
@@ -1097,7 +1097,7 @@
       community.general.nsupdate:
         server: "{{ Common.DNS.Server1.IPv6 }}"
         type: AAAA
-        protocol: udp
+        protocol: "{{ Common.DNS.Server1.Protocol }}"
         zone: "{{ Common.DNS.Domain }}"
         record: "{{ Nested_vCenter.VMName }}"
         value: "{{ Nested_vCenter.Address.IPv6.Address }}"
@@ -1133,7 +1133,7 @@
       community.general.nsupdate:
         server: "{{ Common.DNS.Server1.IPv6 }}"
         type: PTR
-        protocol: udp
+        protocol: "{{ Common.DNS.Server1.Protocol }}"
         zone: "{{ ipv6_reverse_zone }}"
         record: "{{ Nested_vCenter.Address.IPv6.Address | ansible.utils.ipaddr('revdns') }}"
         value: "{{ Nested_vCenter.VMName }}.{{ Common.DNS.Domain }}."
@@ -1189,7 +1189,7 @@
       community.general.nsupdate:
         server: "{{ Common.DNS.Server1.IPv4 }}"
         type: A
-        protocol: udp
+        protocol: "{{ Common.DNS.Server1.Protocol }}"
         zone: "{{ Common.DNS.Domain }}"
         record: "{{ item.value.VMName }}"
         value: "{{ item.value.Address.IPv4.Address }}"
@@ -1227,7 +1227,7 @@
       community.general.nsupdate:
         server: "{{ Common.DNS.Server1.IPv4 }}"
         type: PTR
-        protocol: udp
+        protocol: "{{ Common.DNS.Server1.Protocol }}"
         zone: "{{ ipv4_reverse_zone }}"
         record: "{{ item.value.Address.IPv4.Address | ansible.utils.ipaddr('revdns') }}"
         value: "{{ item.value.VMName }}.{{ Common.DNS.Domain }}."
@@ -1264,7 +1264,7 @@
       community.general.nsupdate:
         server: "{{ Common.DNS.Server1.IPv4 }}"
         type: A
-        protocol: udp
+        protocol: "{{ Common.DNS.Server1.Protocol }}"
         zone: "{{ Common.DNS.Domain }}"
         record: "{{ item.Name }}"
         value: "{{ item.Deployment.ManagementIPAddress }}"
@@ -1300,7 +1300,7 @@
       community.general.nsupdate:
         server: "{{ Common.DNS.Server1.IPv4 }}"
         type: PTR
-        protocol: udp
+        protocol: "{{ Common.DNS.Server1.Protocol }}"
         zone: "{{ ipv4_reverse_zone }}"
         record: "{{ item.Deployment.ManagementIPAddress | ansible.utils.ipaddr('revdns') }}"
         value: "{{ item.Name }}.{{ Common.DNS.Domain }}."
@@ -1345,7 +1345,7 @@
       community.general.nsupdate:
         server: "{{ Common.DNS.Server1.IPv6 }}"
         type: AAAA
-        protocol: udp
+        protocol: "{{ Common.DNS.Server1.Protocol }}"
         zone: "{{ Common.DNS.Domain }}"
         record: "{{ item.value.VMName }}"
         value: "{{ item.value.Address.IPv6.Address }}"
@@ -1383,7 +1383,7 @@
       community.general.nsupdate:
         server: "{{ Common.DNS.Server1.IPv6 }}"
         type: PTR
-        protocol: udp
+        protocol: "{{ Common.DNS.Server1.Protocol }}"
         zone: "{{ ipv6_reverse_zone }}"
         record: "{{ item.value.Address.IPv6.Address | ansible.utils.ipaddr('revdns') }}"
         value: "{{ item.value.VMName }}.{{ Common.DNS.Domain }}."

--- a/software_sample.yml
+++ b/software_sample.yml
@@ -1042,7 +1042,7 @@ Software:
           File: vyos-rolling-latest.iso
           Location: 
             Local: "{{ RootDirectory }}/VyOS/Router/Latest"
-            URL:   "https://s3.amazonaws.com/s3-us.vyos.io/rolling/current"
+            URL:   "{{ lookup('url', 'https://api.github.com/repos/vyos/vyos-rolling-nightly-builds/releases/latest', split_lines=false) | regex_search('browser_download_url.*(https://(.*?).iso)', '\\1') | first }}"
           Version: "0.0"
           FileExt: iso
         Test:

--- a/templates/Ubuntu_v22.04_Netplan.j2
+++ b/templates/Ubuntu_v22.04_Netplan.j2
@@ -1,10 +1,12 @@
 network:
   ethernets:
-    ens33:
+    ens192:
       addresses:
         - {{ Nested_DNSServer.OS.Network.IPv4.Address }}/{{ Nested_DNSServer.OS.Network.IPv4.Prefix }}
         - "{{ Nested_DNSServer.OS.Network.IPv6.Address }}/{{ Nested_DNSServer.OS.Network.IPv6.Prefix }}"
-      gateway4: {{ Nested_DNSServer.OS.Network.IPv4.Gateway }}
+      routes:
+	    - to: default
+		  via: {{ Nested_DNSServer.OS.Network.IPv4.Gateway }}
       nameservers:
         addresses:
           - {{ Nested_DNSServer.OS.Network.IPv4.DNS }}


### PR DESCRIPTION
Updating Netplan template to use new default route syntax
Add ability to specify what ptotocol is used for dns updates
Moved DNS forwarders to be configured up to variables in common instead fo being static towrads the bottom of the config file
Updated router software and deployment to accommidate VyOS being moved to github releases instead of AWS.  Latest rolling nightly gets pulled if nothing is present in the Software repo.
