### PR TITLE
increase pod router memory to 1gb new hw req vyos1.4

### DIFF
--- a/playbooks/DeployRouter.yml
+++ b/playbooks/DeployRouter.yml
@@ -195,7 +195,7 @@
             type: "{{ Common.DiskProvisioning }}"
             datastore: "{{ Target.Datastore }}"
         hardware:
-          memory_mb: "512"
+          memory_mb: "1024"
           num_cpus: "1"
           num_cpu_cores_per_socket: "1"
           scsi: paravirtual


### PR DESCRIPTION
vyos minimum hw requirments incrased to 1gb from 512 around vyos 1.4-1.5.
Trying to push pod config to a 1.5 rolling instance wiht 512mb ram causes the router to go out of memory and processes crash.