### PR TITLE
DNS vars to common, VyOS changes for newer version, netplan syntax updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2150,3 +2150,13 @@
 
 ### Added by Luis Chanu
   - Added ```nslookup``` verification test to end of ```utils/Util_AddIPv4DNSRecord.sh``` script.
+  
+## Dev-v6.0.0 21-SEPTEMBER-2023
+
+### Added by Aaron Ellis
+  - **CONFIG FILE UPDATE**  Updated ```config_sample.yml``` to add DNS protocol and forwarders to common variable section
+  - Updated ```software_sample.yml``` VyOS download URL to account for move to Github Releases  NOTE: keeping the generic filename, will only pull if local Software repo is empty
+  - Updated memory on pod routers to 1gb from 512 in ```playbooks/DeployRouter.yml``` VyOS increased minimum HW specs around version 1.4.  Pushing config to a 1.5 instance was running it out of memory.
+  - Updated ```playbooks/UpdateDNS.yml``` to consume new common DNS vars including selectable protocol for DNS updates
+  - Added retry and increased command timeout when applying pod router config in ```playbooks/ConfigureRouter.yml```  Could be enviromental, could be newer builds, if yours is faster it won't matter.
+  - Updated ```templates/Ubuntu_v22.04_Netplan.j2``` with new syntax for default route in netplan.

--- a/config_sample.yml
+++ b/config_sample.yml
@@ -184,6 +184,10 @@ Common:
     LeaseTime: 3600                                                           # DHCP Lease Time (in seconds) for Overlay Segments
   DNS:
     Domain: SDDC.Lab                                                          # Domain - Default DNS Domain used by all nested components.
+    Forwarder:
+      IPv4: 8.8.8.8                                                           # Forwarder - Default DNS forwarding address used by nested routers.
+      IPv6: 2001:4860:4860::8888                                              # Forwarderv6 - Default DNS IPv6 forwarding address used by nested routers.  
+    Protocol: udp                                                             # Select protocol to be used when adding/updating dns records for pods on the nested DNS server  
     Server1:
       IPv4: "{{ Net.Uplink.IPv4.Network }}.5"                                 # Replace this IP if using a different DNS server than the suggested .5  server in the Router Uplink segment (MUST support Dynamic DNS Updates)
       IPv6: "{{ Net.Uplink.IPv6.Network }}::{{ '%04x'|format(5) }}"           # Replace this IP if using a different DNS server than the suggested ::5 server in the Router Uplink segment (MUST support Dynamic DNS Updates)
@@ -850,11 +854,11 @@ Nested_DNSServer:
         Address: "{{ Net.Uplink.IPv4.Network }}.5" 
         Prefix:  "{{ Net.Uplink.IPv4.Prefix }}"
         Gateway: "{{ Net.Uplink.IPv4.Network }}.1"
-        DNS: 8.8.8.8                                                                    # DNS server reachable by OS to resolve names.  Update as required for your environment.
+        DNS: "{{ Common.DNS.Forwarder.IPv4 }}"                                                                   # DNS server reachable by OS to resolve names.  Update as required for your environment.
       IPv6:
         Address: "{{ Net.Uplink.IPv6.Network }}::{{ '%04x'|format(5) }}" 
         Prefix:  "{{ Net.Uplink.IPv6.Prefix }}"
-        DNS: 2001:4860:4860::8888
+        DNS: "{{ Common.DNS.Forwarder.IPv6 }}"
     Locale: en_US
     Keyboard:
       Layout: us
@@ -862,8 +866,8 @@ Nested_DNSServer:
     Packages:
       BIND:
         Forwarder:
-          IPv4: 8.8.8.8                                                                 # DNS forwarders used by BIND.  Update as required for your environment.
-          IPv6: 2001:4860:4860::8888
+          IPv4: "{{ Common.DNS.Forwarder.IPv4 }}"                                                                 # DNS forwarders used by BIND.  Update as required for your environment.
+          IPv6: "{{ Common.DNS.Forwarder.IPv6 }}"
 
 
 

--- a/playbooks/ConfigureRouter.yml
+++ b/playbooks/ConfigureRouter.yml
@@ -130,12 +130,17 @@
       vyos.vyos.vyos_config:
         src: "{{ Target.TempFolder }}/{{ Deploy.Software.Router.Config }}"
         save: true
+      retries: 5
+      delay: 30
+      register: routerconfig
+      until: routerup.failed == false
       vars:
         ansible_connection: ansible.netcommon.network_cli
         ansible_host: "{{ Nested_Router.Interface.Uplink.IPv4.Address }}"
         ansible_user: vyos
         ansible_password: vyos
         ansible_network_os: vyos.vyos.vyos
+        ansible_command_timeout: 60
       ignore_errors: true
       when:
         - Deploy.Product.Router.Deploy

--- a/playbooks/ConfigureRouter.yml
+++ b/playbooks/ConfigureRouter.yml
@@ -133,7 +133,7 @@
       retries: 5
       delay: 30
       register: routerconfig
-      until: routerup.failed == false
+      until: routerconfig.failed == false
       vars:
         ansible_connection: ansible.netcommon.network_cli
         ansible_host: "{{ Nested_Router.Interface.Uplink.IPv4.Address }}"

--- a/playbooks/DeployRouter.yml
+++ b/playbooks/DeployRouter.yml
@@ -128,7 +128,7 @@
 
     - name: Download VyOS installation media (overwrite if exists)
       ansible.builtin.get_url:
-        url: "{{ Deploy.Software.Router.URL }}/{{ Deploy.Software.Router.File }}"
+        url: "{{ Deploy.Software.Router.URL }}"
         dest: "{{ Target.TempFolder }}/{{ Deploy.Software.Router.Installer }}"
         force: true
         mode: "755"
@@ -195,7 +195,7 @@
             type: "{{ Common.DiskProvisioning }}"
             datastore: "{{ Target.Datastore }}"
         hardware:
-          memory_mb: "512"
+          memory_mb: "1024"
           num_cpus: "1"
           num_cpu_cores_per_socket: "1"
           scsi: paravirtual

--- a/playbooks/UpdateDNS.yml
+++ b/playbooks/UpdateDNS.yml
@@ -87,7 +87,7 @@
                                 Deploy.Setting.UseDNS: {{ Deploy.Setting.UseDNS }}
                                     LOCAL_RecordState: {{ LOCAL_RecordState }}
                                     Common.DNS.Domain: {{ Common.DNS.Domain }}
-                                  Common.DNS.Protocol: {{ Common.DNS.Protocol }}
+                                  Common.DNS.protocol: "{{ Common.DNS.Protocol }}"
                             Common.DNS.Forwarder.IPv4: {{ Common.DNS.Forwarder.IPv4}}
                             Common.DNS.Forwarder.IPv6: {{ Common.DNS.Forwarder.IPv6}}
                               Common.DNS.Server1.IPv4: {{ Common.DNS.Server1.IPv4 }}
@@ -148,7 +148,7 @@
       community.general.nsupdate:
         server: "{{ Common.DNS.Server1.IPv4 }}"
         type: A
-        protocol: {{ Common.DNS.Protocol }}
+        protocol: "{{ Common.DNS.Protocol }}"
         zone: "{{ Common.DNS.Domain }}"
         record: "{{ Nested_Router.Name }}-{{ item.key }}"
         value: "{{ item.value.IPv4.Address }}"
@@ -162,7 +162,7 @@
       community.general.nsupdate:
         server: "{{ Common.DNS.Server1.IPv4 }}"
         type: CNAME
-        protocol: {{ Common.DNS.Protocol }}
+        protocol: "{{ Common.DNS.Protocol }}"
         zone: "{{ Common.DNS.Domain }}"
         record: "{{ Nested_Router.Name }}"
         value: "{{ Nested_Router.Name }}-Uplink"
@@ -197,7 +197,7 @@
       community.general.nsupdate:
         server: "{{ Common.DNS.Server1.IPv4 }}"
         type: PTR
-        protocol: {{ Common.DNS.Protocol }}
+        protocol: "{{ Common.DNS.Protocol }}"
         zone: "{{ ipv4_reverse_zone }}"
         record: "{{ item.value.IPv4.Address | ansible.utils.ipaddr('revdns') }}"
         value: "{{ Nested_Router.Name }}-{{ item.key }}.{{ Common.DNS.Domain }}."
@@ -241,7 +241,7 @@
       community.general.nsupdate:
         server: "{{ Common.DNS.Server1.IPv6 }}"
         type: AAAA
-        protocol: {{ Common.DNS.Protocol }}
+        protocol: "{{ Common.DNS.Protocol }}"
         zone: "{{ Common.DNS.Domain }}"
         record: "{{ Nested_Router.Name }}-{{ item.key }}"
         value: "{{ item.value.IPv6.Address }}"
@@ -277,7 +277,7 @@
       community.general.nsupdate:
         server: "{{ Common.DNS.Server1.IPv6 }}"
         type: PTR
-        protocol: {{ Common.DNS.Protocol }}
+        protocol: "{{ Common.DNS.Protocol }}"
         zone: "{{ ipv6_reverse_zone }}"
         record: "{{ item.value.IPv6.Address | ansible.utils.ipaddr('revdns') }}"
         value: "{{ Nested_Router.Name }}-{{ item.key }}.{{ Common.DNS.Domain }}."
@@ -332,7 +332,7 @@
       community.general.nsupdate:
         server: "{{ Common.DNS.Server1.IPv4 }}"
         type: A
-        protocol: {{ Common.DNS.Protocol }}
+        protocol: "{{ Common.DNS.Protocol }}"
         zone: "{{ Common.DNS.Domain }}"
         record: "{{ item.value.VMName }}"
         value: "{{ item.value.Address.IPv4.Address }}"
@@ -368,7 +368,7 @@
       community.general.nsupdate:
         server: "{{ Common.DNS.Server1.IPv4 }}"
         type: PTR
-        protocol: {{ Common.DNS.Protocol }}
+        protocol: "{{ Common.DNS.Protocol }}"
         zone: "{{ ipv4_reverse_zone }}"
         record: "{{ item.value.Address.IPv4.Address | ansible.utils.ipaddr('revdns') }}"
         value: "{{ item.value.VMName }}.{{ Common.DNS.Domain }}."
@@ -412,7 +412,7 @@
       community.general.nsupdate:
         server: "{{ Common.DNS.Server1.IPv6 }}"
         type: AAAA
-        protocol: {{ Common.DNS.Protocol }}
+        protocol: "{{ Common.DNS.Protocol }}"
         zone: "{{ Common.DNS.Domain }}"
         record: "{{ item.value.VMName }}"
         value: "{{ item.value.Address.IPv6.Address }}"
@@ -448,7 +448,7 @@
       community.general.nsupdate:
         server: "{{ Common.DNS.Server1.IPv6 }}"
         type: PTR
-        protocol: {{ Common.DNS.Protocol }}
+        protocol: "{{ Common.DNS.Protocol }}"
         zone: "{{ ipv6_reverse_zone }}"
         record: "{{ item.value.Address.IPv6.Address | ansible.utils.ipaddr('revdns') }}"
         value: "{{ item.value.VMName }}.{{ Common.DNS.Domain }}."
@@ -503,7 +503,7 @@
       community.general.nsupdate:
         server: "{{ Common.DNS.Server1.IPv4 }}"
         type: A
-        protocol: {{ Common.DNS.Protocol }}
+        protocol: "{{ Common.DNS.Protocol }}"
         zone: "{{ Common.DNS.Domain }}"
         record: "{{ item.value.VMName }}"
         value: "{{ item.value.Address.IPv4.Address }}"
@@ -539,7 +539,7 @@
       community.general.nsupdate:
         server: "{{ Common.DNS.Server1.IPv4 }}"
         type: PTR
-        protocol: {{ Common.DNS.Protocol }}
+        protocol: "{{ Common.DNS.Protocol }}"
         zone: "{{ ipv4_reverse_zone }}"
         record: "{{ item.value.Address.IPv4.Address | ansible.utils.ipaddr('revdns') }}"
         value: "{{ item.value.VMName }}.{{ Common.DNS.Domain }}."
@@ -584,7 +584,7 @@
       community.general.nsupdate:
         server: "{{ Common.DNS.Server1.IPv6 }}"
         type: AAAA
-        protocol: {{ Common.DNS.Protocol }}
+        protocol: "{{ Common.DNS.Protocol }}"
         zone: "{{ Common.DNS.Domain }}"
         record: "{{ item.value.VMName }}"
         value: "{{ item.value.Address.IPv6.Address }}"
@@ -622,7 +622,7 @@
       community.general.nsupdate:
         server: "{{ Common.DNS.Server1.IPv6 }}"
         type: PTR
-        protocol: {{ Common.DNS.Protocol }}
+        protocol: "{{ Common.DNS.Protocol }}"
         zone: "{{ ipv6_reverse_zone }}"
         record: "{{ item.value.Address.IPv6.Address | ansible.utils.ipaddr('revdns') }}"
         value: "{{ item.value.VMName }}.{{ Common.DNS.Domain }}."
@@ -678,7 +678,7 @@
       community.general.nsupdate:
         server: "{{ Common.DNS.Server1.IPv4 }}"
         type: A
-        protocol: {{ Common.DNS.Protocol }}
+        protocol: "{{ Common.DNS.Protocol }}"
         zone: "{{ Common.DNS.Domain }}"
         record: "{{ item.value.VMName }}"
         value: "{{ item.value.Address.IPv4.Address }}"
@@ -714,7 +714,7 @@
       community.general.nsupdate:
         server: "{{ Common.DNS.Server1.IPv4 }}"
         type: PTR
-        protocol: {{ Common.DNS.Protocol }}
+        protocol: "{{ Common.DNS.Protocol }}"
         zone: "{{ ipv4_reverse_zone }}"
         record: "{{ item.value.Address.IPv4.Address | ansible.utils.ipaddr('revdns') }}"
         value: "{{ item.value.VMName }}.{{ Common.DNS.Domain }}."
@@ -758,7 +758,7 @@
       community.general.nsupdate:
         server: "{{ Common.DNS.Server1.IPv6 }}"
         type: AAAA
-        protocol: {{ Common.DNS.Protocol }}
+        protocol: "{{ Common.DNS.Protocol }}"
         zone: "{{ Common.DNS.Domain }}"
         record: "{{ item.value.VMName }}"
         value: "{{ item.value.Address.IPv6.Address }}"
@@ -794,7 +794,7 @@
       community.general.nsupdate:
         server: "{{ Common.DNS.Server1.IPv6 }}"
         type: PTR
-        protocol: {{ Common.DNS.Protocol }}
+        protocol: "{{ Common.DNS.Protocol }}"
         zone: "{{ ipv6_reverse_zone }}"
         record: "{{ item.value.Address.IPv6.Address | ansible.utils.ipaddr('revdns') }}"
         value: "{{ item.value.VMName }}.{{ Common.DNS.Domain }}."
@@ -849,7 +849,7 @@
       community.general.nsupdate:
         server: "{{ Common.DNS.Server1.IPv4 }}"
         type: A
-        protocol: {{ Common.DNS.Protocol }}
+        protocol: "{{ Common.DNS.Protocol }}"
         zone: "{{ Common.DNS.Domain }}"
         record: "{{ item.value.VMName }}"
         value: "{{ item.value.vmk.vmk0.Address.IPv4.Address }}"
@@ -885,7 +885,7 @@
       community.general.nsupdate:
         server: "{{ Common.DNS.Server1.IPv4 }}"
         type: PTR
-        protocol: {{ Common.DNS.Protocol }}
+        protocol: "{{ Common.DNS.Protocol }}"
         zone: "{{ ipv4_reverse_zone }}"
         record: "{{ item.value.vmk.vmk0.Address.IPv4.Address | ansible.utils.ipaddr('revdns') }}"
         value: "{{ item.value.VMName }}.{{ Common.DNS.Domain }}."
@@ -930,7 +930,7 @@
       community.general.nsupdate:
         server: "{{ Common.DNS.Server1.IPv6 }}"
         type: AAAA
-        protocol: {{ Common.DNS.Protocol }}
+        protocol: "{{ Common.DNS.Protocol }}"
         zone: "{{ Common.DNS.Domain }}"
         record: "{{ item.value.VMName }}"
         value: "{{ item.value.vmk.vmk0.Address.IPv6.Address }}"
@@ -968,7 +968,7 @@
       community.general.nsupdate:
         server: "{{ Common.DNS.Server1.IPv6 }}"
         type: PTR
-        protocol: {{ Common.DNS.Protocol }}
+        protocol: "{{ Common.DNS.Protocol }}"
         zone: "{{ ipv6_reverse_zone }}"
         record: "{{ item.value.vmk.vmk0.Address.IPv6.Address | ansible.utils.ipaddr('revdns') }}"
         value: "{{ item.value.VMName }}.{{ Common.DNS.Domain }}."
@@ -1023,7 +1023,7 @@
       community.general.nsupdate:
         server: "{{ Common.DNS.Server1.IPv4 }}"
         type: A
-        protocol: {{ Common.DNS.Protocol }}
+        protocol: "{{ Common.DNS.Protocol }}"
         zone: "{{ Common.DNS.Domain }}"
         record: "{{ Nested_vCenter.VMName }}"
         value: "{{ Nested_vCenter.Address.IPv4.Address }}"
@@ -1057,7 +1057,7 @@
       community.general.nsupdate:
         server: "{{ Common.DNS.Server1.IPv4 }}"
         type: PTR
-        protocol: {{ Common.DNS.Protocol }}
+        protocol: "{{ Common.DNS.Protocol }}"
         zone: "{{ ipv4_reverse_zone }}"
         record: "{{ Nested_vCenter.Address.IPv4.Address | ansible.utils.ipaddr('revdns') }}"
         value: "{{ Nested_vCenter.VMName }}.{{ Common.DNS.Domain }}."
@@ -1100,7 +1100,7 @@
       community.general.nsupdate:
         server: "{{ Common.DNS.Server1.IPv6 }}"
         type: AAAA
-        protocol: {{ Common.DNS.Protocol }}
+        protocol: "{{ Common.DNS.Protocol }}"
         zone: "{{ Common.DNS.Domain }}"
         record: "{{ Nested_vCenter.VMName }}"
         value: "{{ Nested_vCenter.Address.IPv6.Address }}"
@@ -1136,7 +1136,7 @@
       community.general.nsupdate:
         server: "{{ Common.DNS.Server1.IPv6 }}"
         type: PTR
-        protocol: {{ Common.DNS.Protocol }}
+        protocol: "{{ Common.DNS.Protocol }}"
         zone: "{{ ipv6_reverse_zone }}"
         record: "{{ Nested_vCenter.Address.IPv6.Address | ansible.utils.ipaddr('revdns') }}"
         value: "{{ Nested_vCenter.VMName }}.{{ Common.DNS.Domain }}."
@@ -1192,7 +1192,7 @@
       community.general.nsupdate:
         server: "{{ Common.DNS.Server1.IPv4 }}"
         type: A
-        protocol: {{ Common.DNS.Protocol }}
+        protocol: "{{ Common.DNS.Protocol }}"
         zone: "{{ Common.DNS.Domain }}"
         record: "{{ item.value.VMName }}"
         value: "{{ item.value.Address.IPv4.Address }}"
@@ -1230,7 +1230,7 @@
       community.general.nsupdate:
         server: "{{ Common.DNS.Server1.IPv4 }}"
         type: PTR
-        protocol: {{ Common.DNS.Protocol }}
+        protocol: "{{ Common.DNS.Protocol }}"
         zone: "{{ ipv4_reverse_zone }}"
         record: "{{ item.value.Address.IPv4.Address | ansible.utils.ipaddr('revdns') }}"
         value: "{{ item.value.VMName }}.{{ Common.DNS.Domain }}."
@@ -1267,7 +1267,7 @@
       community.general.nsupdate:
         server: "{{ Common.DNS.Server1.IPv4 }}"
         type: A
-        protocol: {{ Common.DNS.Protocol }}
+        protocol: "{{ Common.DNS.Protocol }}"
         zone: "{{ Common.DNS.Domain }}"
         record: "{{ item.Name }}"
         value: "{{ item.Deployment.ManagementIPAddress }}"
@@ -1303,7 +1303,7 @@
       community.general.nsupdate:
         server: "{{ Common.DNS.Server1.IPv4 }}"
         type: PTR
-        protocol: {{ Common.DNS.Protocol }}
+        protocol: "{{ Common.DNS.Protocol }}"
         zone: "{{ ipv4_reverse_zone }}"
         record: "{{ item.Deployment.ManagementIPAddress | ansible.utils.ipaddr('revdns') }}"
         value: "{{ item.Name }}.{{ Common.DNS.Domain }}."
@@ -1348,7 +1348,7 @@
       community.general.nsupdate:
         server: "{{ Common.DNS.Server1.IPv6 }}"
         type: AAAA
-        protocol: {{ Common.DNS.Protocol }}
+        protocol: "{{ Common.DNS.Protocol }}"
         zone: "{{ Common.DNS.Domain }}"
         record: "{{ item.value.VMName }}"
         value: "{{ item.value.Address.IPv6.Address }}"
@@ -1386,7 +1386,7 @@
       community.general.nsupdate:
         server: "{{ Common.DNS.Server1.IPv6 }}"
         type: PTR
-        protocol: {{ Common.DNS.Protocol }}
+        protocol: "{{ Common.DNS.Protocol }}"
         zone: "{{ ipv6_reverse_zone }}"
         record: "{{ item.value.Address.IPv6.Address | ansible.utils.ipaddr('revdns') }}"
         value: "{{ item.value.VMName }}.{{ Common.DNS.Domain }}."

--- a/playbooks/UpdateDNS.yml
+++ b/playbooks/UpdateDNS.yml
@@ -87,6 +87,9 @@
                                 Deploy.Setting.UseDNS: {{ Deploy.Setting.UseDNS }}
                                     LOCAL_RecordState: {{ LOCAL_RecordState }}
                                     Common.DNS.Domain: {{ Common.DNS.Domain }}
+                                  Common.DNS.Protocol: {{ Common.DNS.Protocol }}
+                            Common.DNS.Forwarder.IPv4: {{ Common.DNS.Forwarder.IPv4}}
+                            Common.DNS.Forwarder.IPv6: {{ Common.DNS.Forwarder.IPv6}}
                               Common.DNS.Server1.IPv4: {{ Common.DNS.Server1.IPv4 }}
                               Common.DNS.Server1.IPv6: {{ Common.DNS.Server1.IPv6 }}
 
@@ -145,7 +148,7 @@
       community.general.nsupdate:
         server: "{{ Common.DNS.Server1.IPv4 }}"
         type: A
-        protocol: udp
+        protocol: {{ Common.DNS.Protocol }}
         zone: "{{ Common.DNS.Domain }}"
         record: "{{ Nested_Router.Name }}-{{ item.key }}"
         value: "{{ item.value.IPv4.Address }}"
@@ -159,7 +162,7 @@
       community.general.nsupdate:
         server: "{{ Common.DNS.Server1.IPv4 }}"
         type: CNAME
-        protocol: udp
+        protocol: {{ Common.DNS.Protocol }}
         zone: "{{ Common.DNS.Domain }}"
         record: "{{ Nested_Router.Name }}"
         value: "{{ Nested_Router.Name }}-Uplink"
@@ -194,7 +197,7 @@
       community.general.nsupdate:
         server: "{{ Common.DNS.Server1.IPv4 }}"
         type: PTR
-        protocol: udp
+        protocol: {{ Common.DNS.Protocol }}
         zone: "{{ ipv4_reverse_zone }}"
         record: "{{ item.value.IPv4.Address | ansible.utils.ipaddr('revdns') }}"
         value: "{{ Nested_Router.Name }}-{{ item.key }}.{{ Common.DNS.Domain }}."
@@ -238,7 +241,7 @@
       community.general.nsupdate:
         server: "{{ Common.DNS.Server1.IPv6 }}"
         type: AAAA
-        protocol: udp
+        protocol: {{ Common.DNS.Protocol }}
         zone: "{{ Common.DNS.Domain }}"
         record: "{{ Nested_Router.Name }}-{{ item.key }}"
         value: "{{ item.value.IPv6.Address }}"
@@ -274,7 +277,7 @@
       community.general.nsupdate:
         server: "{{ Common.DNS.Server1.IPv6 }}"
         type: PTR
-        protocol: udp
+        protocol: {{ Common.DNS.Protocol }}
         zone: "{{ ipv6_reverse_zone }}"
         record: "{{ item.value.IPv6.Address | ansible.utils.ipaddr('revdns') }}"
         value: "{{ Nested_Router.Name }}-{{ item.key }}.{{ Common.DNS.Domain }}."
@@ -329,7 +332,7 @@
       community.general.nsupdate:
         server: "{{ Common.DNS.Server1.IPv4 }}"
         type: A
-        protocol: udp
+        protocol: {{ Common.DNS.Protocol }}
         zone: "{{ Common.DNS.Domain }}"
         record: "{{ item.value.VMName }}"
         value: "{{ item.value.Address.IPv4.Address }}"
@@ -365,7 +368,7 @@
       community.general.nsupdate:
         server: "{{ Common.DNS.Server1.IPv4 }}"
         type: PTR
-        protocol: udp
+        protocol: {{ Common.DNS.Protocol }}
         zone: "{{ ipv4_reverse_zone }}"
         record: "{{ item.value.Address.IPv4.Address | ansible.utils.ipaddr('revdns') }}"
         value: "{{ item.value.VMName }}.{{ Common.DNS.Domain }}."
@@ -409,7 +412,7 @@
       community.general.nsupdate:
         server: "{{ Common.DNS.Server1.IPv6 }}"
         type: AAAA
-        protocol: udp
+        protocol: {{ Common.DNS.Protocol }}
         zone: "{{ Common.DNS.Domain }}"
         record: "{{ item.value.VMName }}"
         value: "{{ item.value.Address.IPv6.Address }}"
@@ -445,7 +448,7 @@
       community.general.nsupdate:
         server: "{{ Common.DNS.Server1.IPv6 }}"
         type: PTR
-        protocol: udp
+        protocol: {{ Common.DNS.Protocol }}
         zone: "{{ ipv6_reverse_zone }}"
         record: "{{ item.value.Address.IPv6.Address | ansible.utils.ipaddr('revdns') }}"
         value: "{{ item.value.VMName }}.{{ Common.DNS.Domain }}."
@@ -500,7 +503,7 @@
       community.general.nsupdate:
         server: "{{ Common.DNS.Server1.IPv4 }}"
         type: A
-        protocol: udp
+        protocol: {{ Common.DNS.Protocol }}
         zone: "{{ Common.DNS.Domain }}"
         record: "{{ item.value.VMName }}"
         value: "{{ item.value.Address.IPv4.Address }}"
@@ -536,7 +539,7 @@
       community.general.nsupdate:
         server: "{{ Common.DNS.Server1.IPv4 }}"
         type: PTR
-        protocol: udp
+        protocol: {{ Common.DNS.Protocol }}
         zone: "{{ ipv4_reverse_zone }}"
         record: "{{ item.value.Address.IPv4.Address | ansible.utils.ipaddr('revdns') }}"
         value: "{{ item.value.VMName }}.{{ Common.DNS.Domain }}."
@@ -581,7 +584,7 @@
       community.general.nsupdate:
         server: "{{ Common.DNS.Server1.IPv6 }}"
         type: AAAA
-        protocol: udp
+        protocol: {{ Common.DNS.Protocol }}
         zone: "{{ Common.DNS.Domain }}"
         record: "{{ item.value.VMName }}"
         value: "{{ item.value.Address.IPv6.Address }}"
@@ -619,7 +622,7 @@
       community.general.nsupdate:
         server: "{{ Common.DNS.Server1.IPv6 }}"
         type: PTR
-        protocol: udp
+        protocol: {{ Common.DNS.Protocol }}
         zone: "{{ ipv6_reverse_zone }}"
         record: "{{ item.value.Address.IPv6.Address | ansible.utils.ipaddr('revdns') }}"
         value: "{{ item.value.VMName }}.{{ Common.DNS.Domain }}."
@@ -675,7 +678,7 @@
       community.general.nsupdate:
         server: "{{ Common.DNS.Server1.IPv4 }}"
         type: A
-        protocol: udp
+        protocol: {{ Common.DNS.Protocol }}
         zone: "{{ Common.DNS.Domain }}"
         record: "{{ item.value.VMName }}"
         value: "{{ item.value.Address.IPv4.Address }}"
@@ -711,7 +714,7 @@
       community.general.nsupdate:
         server: "{{ Common.DNS.Server1.IPv4 }}"
         type: PTR
-        protocol: udp
+        protocol: {{ Common.DNS.Protocol }}
         zone: "{{ ipv4_reverse_zone }}"
         record: "{{ item.value.Address.IPv4.Address | ansible.utils.ipaddr('revdns') }}"
         value: "{{ item.value.VMName }}.{{ Common.DNS.Domain }}."
@@ -755,7 +758,7 @@
       community.general.nsupdate:
         server: "{{ Common.DNS.Server1.IPv6 }}"
         type: AAAA
-        protocol: udp
+        protocol: {{ Common.DNS.Protocol }}
         zone: "{{ Common.DNS.Domain }}"
         record: "{{ item.value.VMName }}"
         value: "{{ item.value.Address.IPv6.Address }}"
@@ -791,7 +794,7 @@
       community.general.nsupdate:
         server: "{{ Common.DNS.Server1.IPv6 }}"
         type: PTR
-        protocol: udp
+        protocol: {{ Common.DNS.Protocol }}
         zone: "{{ ipv6_reverse_zone }}"
         record: "{{ item.value.Address.IPv6.Address | ansible.utils.ipaddr('revdns') }}"
         value: "{{ item.value.VMName }}.{{ Common.DNS.Domain }}."
@@ -846,7 +849,7 @@
       community.general.nsupdate:
         server: "{{ Common.DNS.Server1.IPv4 }}"
         type: A
-        protocol: udp
+        protocol: {{ Common.DNS.Protocol }}
         zone: "{{ Common.DNS.Domain }}"
         record: "{{ item.value.VMName }}"
         value: "{{ item.value.vmk.vmk0.Address.IPv4.Address }}"
@@ -882,7 +885,7 @@
       community.general.nsupdate:
         server: "{{ Common.DNS.Server1.IPv4 }}"
         type: PTR
-        protocol: udp
+        protocol: {{ Common.DNS.Protocol }}
         zone: "{{ ipv4_reverse_zone }}"
         record: "{{ item.value.vmk.vmk0.Address.IPv4.Address | ansible.utils.ipaddr('revdns') }}"
         value: "{{ item.value.VMName }}.{{ Common.DNS.Domain }}."
@@ -927,7 +930,7 @@
       community.general.nsupdate:
         server: "{{ Common.DNS.Server1.IPv6 }}"
         type: AAAA
-        protocol: udp
+        protocol: {{ Common.DNS.Protocol }}
         zone: "{{ Common.DNS.Domain }}"
         record: "{{ item.value.VMName }}"
         value: "{{ item.value.vmk.vmk0.Address.IPv6.Address }}"
@@ -965,7 +968,7 @@
       community.general.nsupdate:
         server: "{{ Common.DNS.Server1.IPv6 }}"
         type: PTR
-        protocol: udp
+        protocol: {{ Common.DNS.Protocol }}
         zone: "{{ ipv6_reverse_zone }}"
         record: "{{ item.value.vmk.vmk0.Address.IPv6.Address | ansible.utils.ipaddr('revdns') }}"
         value: "{{ item.value.VMName }}.{{ Common.DNS.Domain }}."
@@ -1020,7 +1023,7 @@
       community.general.nsupdate:
         server: "{{ Common.DNS.Server1.IPv4 }}"
         type: A
-        protocol: udp
+        protocol: {{ Common.DNS.Protocol }}
         zone: "{{ Common.DNS.Domain }}"
         record: "{{ Nested_vCenter.VMName }}"
         value: "{{ Nested_vCenter.Address.IPv4.Address }}"
@@ -1054,7 +1057,7 @@
       community.general.nsupdate:
         server: "{{ Common.DNS.Server1.IPv4 }}"
         type: PTR
-        protocol: udp
+        protocol: {{ Common.DNS.Protocol }}
         zone: "{{ ipv4_reverse_zone }}"
         record: "{{ Nested_vCenter.Address.IPv4.Address | ansible.utils.ipaddr('revdns') }}"
         value: "{{ Nested_vCenter.VMName }}.{{ Common.DNS.Domain }}."
@@ -1097,7 +1100,7 @@
       community.general.nsupdate:
         server: "{{ Common.DNS.Server1.IPv6 }}"
         type: AAAA
-        protocol: udp
+        protocol: {{ Common.DNS.Protocol }}
         zone: "{{ Common.DNS.Domain }}"
         record: "{{ Nested_vCenter.VMName }}"
         value: "{{ Nested_vCenter.Address.IPv6.Address }}"
@@ -1133,7 +1136,7 @@
       community.general.nsupdate:
         server: "{{ Common.DNS.Server1.IPv6 }}"
         type: PTR
-        protocol: udp
+        protocol: {{ Common.DNS.Protocol }}
         zone: "{{ ipv6_reverse_zone }}"
         record: "{{ Nested_vCenter.Address.IPv6.Address | ansible.utils.ipaddr('revdns') }}"
         value: "{{ Nested_vCenter.VMName }}.{{ Common.DNS.Domain }}."
@@ -1189,7 +1192,7 @@
       community.general.nsupdate:
         server: "{{ Common.DNS.Server1.IPv4 }}"
         type: A
-        protocol: udp
+        protocol: {{ Common.DNS.Protocol }}
         zone: "{{ Common.DNS.Domain }}"
         record: "{{ item.value.VMName }}"
         value: "{{ item.value.Address.IPv4.Address }}"
@@ -1227,7 +1230,7 @@
       community.general.nsupdate:
         server: "{{ Common.DNS.Server1.IPv4 }}"
         type: PTR
-        protocol: udp
+        protocol: {{ Common.DNS.Protocol }}
         zone: "{{ ipv4_reverse_zone }}"
         record: "{{ item.value.Address.IPv4.Address | ansible.utils.ipaddr('revdns') }}"
         value: "{{ item.value.VMName }}.{{ Common.DNS.Domain }}."
@@ -1264,7 +1267,7 @@
       community.general.nsupdate:
         server: "{{ Common.DNS.Server1.IPv4 }}"
         type: A
-        protocol: udp
+        protocol: {{ Common.DNS.Protocol }}
         zone: "{{ Common.DNS.Domain }}"
         record: "{{ item.Name }}"
         value: "{{ item.Deployment.ManagementIPAddress }}"
@@ -1300,7 +1303,7 @@
       community.general.nsupdate:
         server: "{{ Common.DNS.Server1.IPv4 }}"
         type: PTR
-        protocol: udp
+        protocol: {{ Common.DNS.Protocol }}
         zone: "{{ ipv4_reverse_zone }}"
         record: "{{ item.Deployment.ManagementIPAddress | ansible.utils.ipaddr('revdns') }}"
         value: "{{ item.Name }}.{{ Common.DNS.Domain }}."
@@ -1345,7 +1348,7 @@
       community.general.nsupdate:
         server: "{{ Common.DNS.Server1.IPv6 }}"
         type: AAAA
-        protocol: udp
+        protocol: {{ Common.DNS.Protocol }}
         zone: "{{ Common.DNS.Domain }}"
         record: "{{ item.value.VMName }}"
         value: "{{ item.value.Address.IPv6.Address }}"
@@ -1383,7 +1386,7 @@
       community.general.nsupdate:
         server: "{{ Common.DNS.Server1.IPv6 }}"
         type: PTR
-        protocol: udp
+        protocol: {{ Common.DNS.Protocol }}
         zone: "{{ ipv6_reverse_zone }}"
         record: "{{ item.value.Address.IPv6.Address | ansible.utils.ipaddr('revdns') }}"
         value: "{{ item.value.VMName }}.{{ Common.DNS.Domain }}."

--- a/software_sample.yml
+++ b/software_sample.yml
@@ -1042,7 +1042,7 @@ Software:
           File: vyos-rolling-latest.iso
           Location: 
             Local: "{{ RootDirectory }}/VyOS/Router/Latest"
-            URL:   "https://s3.amazonaws.com/s3-us.vyos.io/rolling/current"
+            URL:   "{{ lookup('url', 'https://api.github.com/repos/vyos/vyos-rolling-nightly-builds/releases/latest', split_lines=false) | regex_search('browser_download_url.*(https://(.*?).iso)', '\\1') | first }}"
           Version: "0.0"
           FileExt: iso
         Test:
@@ -1050,6 +1050,6 @@ Software:
           File: vyos-rolling-latest.iso
           Location: 
             Local: "{{ RootDirectory }}/VyOS/Router/Test"
-            URL:   "https://s3.amazonaws.com/s3-us.vyos.io/rolling/current"
+            URL:   "{{ lookup('url', 'https://api.github.com/repos/vyos/vyos-rolling-nightly-builds/releases/latest', split_lines=false) | regex_search('browser_download_url.*(https://(.*?).iso)', '\\1') | first }}"
           Version: "0.0"
           FileExt: iso

--- a/templates/Ubuntu_v22.04_Netplan.j2
+++ b/templates/Ubuntu_v22.04_Netplan.j2
@@ -1,10 +1,12 @@
 network:
   ethernets:
-    ens33:
+    ens192:
       addresses:
         - {{ Nested_DNSServer.OS.Network.IPv4.Address }}/{{ Nested_DNSServer.OS.Network.IPv4.Prefix }}
         - "{{ Nested_DNSServer.OS.Network.IPv6.Address }}/{{ Nested_DNSServer.OS.Network.IPv6.Prefix }}"
-      gateway4: {{ Nested_DNSServer.OS.Network.IPv4.Gateway }}
+      routes:
+	    - to: default
+		  via: {{ Nested_DNSServer.OS.Network.IPv4.Gateway }}
       nameservers:
         addresses:
           - {{ Nested_DNSServer.OS.Network.IPv4.DNS }}


### PR DESCRIPTION
  - **CONFIG FILE UPDATE**  Updated ```config_sample.yml``` to add DNS protocol and forwarders to common variable section
  - Updated ```software_sample.yml``` VyOS download URL to account for move to Github Releases  NOTE: keeping the generic filename, will only pull if local Software repo is empty
  - Updated memory on pod routers to 1gb from 512 in ```playbooks/DeployRouter.yml``` VyOS increased minimum HW specs around version 1.4.  Pushing config to a 1.5 instance was running it out of memory.
  - Updated ```playbooks/UpdateDNS.yml``` to consume new common DNS vars including selectable protocol for DNS updates
  - Added retry and increased command timeout when applying pod router config in ```playbooks/ConfigureRouter.yml```  Could be enviromental, could be newer builds, if yours is faster it won't matter.
  - Updated ```templates/Ubuntu_v22.04_Netplan.j2``` with new syntax for default route in netplan.