### PR TITLE
require vmware 3.9.0 collection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2168,3 +2168,9 @@
   - Added vCenter Server and ESXi v8.00 Update 2 to Software repository (UNTESTED).
   - Updated ```software_sample.yml``` and ```templates_sample.yml``` to support v8.00 Update 2.
   - Be sure to update your ```software.yml``` and ```templates.yml``` files.
+
+## Dev-v6.0.0 25-SEPTEMBER-2023
+
+### Added by Aaron Ellis
+  - Updated ```requirements.yml``` for community.vmware collection version 3.9.0, 3.8.0 intriduced a bug in vmware_deploy_ovf https://github.com/ansible-collections/community.vmware/issues/1808
+  - Updated ```playbooks/DeployDNSServer.yml``` to correct some errors in dubug output

--- a/playbooks/DeployDNSServer.yml
+++ b/playbooks/DeployDNSServer.yml
@@ -75,8 +75,7 @@
                           Ubuntu VM Network PortGroup: {{ Nested_DNSServer.VM.HardwareSettings.PortGroup }}
 
                                   Ubuntu IPv4 Address: {{ Nested_DNSServer.OS.Network.IPv4.Address }}
-                               Ubuntu Network Netmask: {{ (Nested_DNSServer.OS.Network.IPv4.Address + '/' + Nested_DNSServer.OS.Network.IPv4.Prefix)\
-                                                         | ansible.utils.ipaddr('netmask') }}
+                               Ubuntu Network Netmask: {{ (Nested_DNSServer.OS.Network.IPv4.Address + '/' + Nested_DNSServer.OS.Network.IPv4.Prefix)| ansible.utils.ipaddr('netmask') }}
                           Ubuntu Network IPv4 Gateway: {{ Nested_DNSServer.OS.Network.IPv4.Gateway }}
 
                                     Ubuntu Media Path: {{ Deploy.Software.DNSServer.Directory }}
@@ -122,7 +121,7 @@
           =================================================================================================
       when:
         - DEBUG.DisplayVariables
-        - var_ubuntuconfiguration != ""
+        - var_ubuntuconfiguration is defined:
         - ubuntu_status is failed
         - Deploy.Product.DNSServer.Deploy
 

--- a/requirements.yml
+++ b/requirements.yml
@@ -7,7 +7,7 @@
 collections:
   - name: community.general
   - name: community.vmware
-    version: 3.8.0
+    version: 3.9.0
   - name: community.crypto
   - name: vyos.vyos
     version: 3.0.1


### PR DESCRIPTION
  - Updated ```requirements.yml``` for community.vmware collection version 3.9.0, 3.8.0 intriduced a bug in vmware_deploy_ovf https://github.com/ansible-collections/community.vmware/issues/1808
  - Updated ```playbooks/DeployDNSServer.yml``` to correct some errors in dubug output
