### PR TITLE
Fix issue with pip3 ansible package v10.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2526,4 +2526,9 @@
 ### Added by Rutger Blom
   - Added vCenter Server v8.0.0 Update 3 to ```software_sample.yml``` (NOT TESTED)
   - Added ESXi v8.0.0 Update 3 to to ```software_sample.yml``` (NOT TESTED)
-  - Be sure to update your ```software.yml``` and ```templates.yml```file.
+  - Be sure to update your ```software.yml``` and ```templates.yml``` file.
+
+## Dev-v7.0.0 09-JULY-2024
+
+### Added by Luis Chanu
+  - Discovered issue with pip3 ansible v10.1.0 package where ```#!/usr/bin/env python``` fails in library python modules with ```"/bin/sh: 1: /usr/bin/env python: not found\n"``` error message.  Reverting back to ansible version 9.7.0 package corrected this issue.  For that reason, ```pip3_requirements.txt``` file updated to install version 9.7.0 of the pip3 ansible package.

--- a/README.md
+++ b/README.md
@@ -484,6 +484,7 @@ As we use SDDC.Lab in our labs, every now-and-then we notice some issues/problem
 | 11-OCT-2022 | 8.0.0 (Build  20519528) | 8.0.0 (Build 20513097) | 4.0.0.1 | Although v8.0.0 of vCenter Server and ESXi deploy successfully using SDDC.Lab, NSX fails when it attempts to apply the Transport Node Profile to the vSphere cluster.  It fails with the following error message, "```NSX cannot be enabled on the cluster because it contains host 6e6954ea-2f6a-491a-a3d4-34ea27078709:host-14 of unsupported version.```"  So, it appears the next version of NSX is required in order to support vSphere 8.0.0 (GA). | Luis Chanu |
 | 14-OCT-2022 | 8.0.0 (Build  20519528) | 8.0.0 (Build 20513097) | 4.0.1.1 | NSX-T Federation deployment is not supported due to a Federation onboarding bug with NSX where the Segment paths are not correct within vCenter Server. | Luis Chanu |
 | 26-APR-2023 | 7.0.0U3L | 7.0.0U3L | 3.2.2.1 | NSX-T Federation deployment is not supported due to a Federation onboarding bug with NSX where the Segment paths are not correct within vCenter Server.  This is the same issue discovered with NSX v4.0.1.1.  | Luis Chanu |
+| 09-JUL-2024 | N/A | N/A | N/A | PIP3 ansible package v10.1.0 causes ```"/bin/sh: 1: /usr/bin/env python: not found\n"``` failure during deployment.  Solution is to install ansible package v9.7.0. | Luis Chanu |
 
 
 ## More Information

--- a/pip3_requirements.txt
+++ b/pip3_requirements.txt
@@ -1,4 +1,6 @@
-ansible
+# ansible v10.1.0 causes '#!/usr/bin/env python' statements in library modules to fail with the following error: "/bin/sh: 1: /usr/bin/env python: not found\n"
+# This issue is not present in v9.7.0
+ansible==9.7.0
 pyvim
 pyvmomi
 pyopenssl 


### PR DESCRIPTION
This pull request corrects the issue with pip3 ansible package v10.1.0 where invocations of `#!/usr/bin/env python` in scripts causes them to fail, complaining it cannot find python.  Fix is to use v9.7.0 instead.