### PR TITLE
Update 'CreatePodConfig' message on time to run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2557,4 +2557,9 @@
 ## Dev-v7.0.0 05-AUGUST-2024
 
 ### Added by Rutger Blom
-  - Increased the value of certain timers in ```playbooks/DeployRouter.yml```. 
+  - Increased the value of certain timers in ```playbooks/DeployRouter.yml```.
+
+## Dev-v7.0.0 05-AUGUST-2024
+
+### Added by Luis Chanu
+  - Newer Ansible versions are allowing ```playbooks/CreatePodConfig.yml``` to run much faster than previously.  So, modified how long it takes to generate a static Pod configuration.

--- a/playbooks/CreatePodConfig.yml
+++ b/playbooks/CreatePodConfig.yml
@@ -113,9 +113,9 @@
           =============================================  NOTICE  =============================================
           ====================================================================================================
 
-          Generating static configuration file for Pod {{ Pod.Number }}.   Please be patient, as this can take
-          some time.  On average, it takes between 15 to 20 minutes to complete, but this varies depending
-          on the size of your lab, and the speed of your Ansible Control Station (a.k.a. Ansible Controller).
+          Generating static configuration file for Pod {{ Pod.Number }}.  Please be patient, as this can take
+          some time.  On average, it takes several minutes to complete, but this varies depending on the size
+          of your lab, and the speed of your Ansible Control Station (a.k.a. Ansible Controller).
 
               The following source file is being prepared: {{ SourceConfigPath }}/{{ SourceConfigFile }}
              Once prepared, it will be saved to this file: {{ lookup('env', 'HOME') }}/{{ PodConfigFile }}


### PR DESCRIPTION
Changed verbiage to indicate it can take "several minutes" instead of an explicit range.