### PR TITLE
Place all install files under the 'Installer' directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2708,3 +2708,10 @@
   - Updated ```playbooks/ConfigureAlbClouds.yml``` so that the VM folder name and not its ID is used in the payload to configure the SE Group.
   - Added new setting "Deploy.Setting.DeployESXiOnly" to the ```config_sample.yml``` file. Setting this to "true" will deploy a Pod with a router, DNS server (optional), and nested ESXi hosts only.
   - Be sure to update your ```config.yml``` file
+
+## Dev-v8.0.0 29-SEPTEMBER-2024
+
+### Added by Luis Chanu
+  - Modified ```Include_Tasks_DeployGenericVm.yml``` to place all deployment related files under ```{{ VMTarget.TempFolder }}/{{ VMTarget.Installer }}```.  This makes cleanup easier as rather than removing each of the other files individually throughout the playbook, the 'cleanup' was moved to the end, in one command.
+  - Modified the ```Target.ISOFolder``` variable in ```config_sample.yml``` to have an underscore at the beginning of the dirctory name.
+  - Be sure to update your ```config.yml``` file, then delete the old ```SDDCLab-ISO-Folder``` in your datastore at a point when you are not deploying any Pods.

--- a/config_sample.yml
+++ b/config_sample.yml
@@ -276,7 +276,7 @@ TargetConfig:
     Cluster: ''
     Datastore: Local_VMs                                                      # Datastore - The datastore connected to your physicsal ESXi host
     VMFolder: ha-datacenter/vm
-    ISOFolder: /SDDCLab-ISO-Folder
+    ISOFolder: /_SDDCLab-ISO-Folder
     TempFolder: "{{ lookup('env','HOME') }}/SDDC.Lab/{{ SiteCode }}"          # TempFolder - Temporary folder location used for temporary files created during the deployment process
     TemplateFolder: ../templates
     PortGroup:
@@ -297,7 +297,7 @@ TargetConfig:
     Cluster: Lab-Cluster                                                      # Cluster - Defines which vSphere cluster within DataCenter the lab Pod's are deployed
     Datastore: Shared_VMs                                                     # Datastore - Defines Which datastore should the nested lab Pod VMs be placed
     VMFolder: "SDDC Pods/{{ SiteCode }}"                                      # VMFolder - Deployed lab Pod VMs are placed within this VMFolder
-    ISOFolder: /SDDCLab-ISO-Folder                                            # ISOFolder - Directory created within Datastore where custom created ISOs are placed as part of the nested lab deployment
+    ISOFolder: /_SDDCLab-ISO-Folder                                            # ISOFolder - Directory created within Datastore where custom created ISOs are placed as part of the nested lab deployment
     TempFolder: "{{ lookup('env','HOME') }}/SDDC.Lab/{{ SiteCode }}"          # TempFolder - Temporary folder location used for temporary files created during the deployment process
     TemplateFolder: ../templates                                              # TemplateFolder - The location of the "templates" folder, relative to teh "playbooks" directory
     PortGroup:                                                                # Various PortGroups used during deployment

--- a/playbooks/DeployGenericVms.yml
+++ b/playbooks/DeployGenericVms.yml
@@ -21,6 +21,7 @@
 ##
 ## ToDo Items:
 ##   1) Add Ubuntu section in Templates.yml for different versions of Ubuntu.
+##   2) Look at 'minimal' install flag in Cloud-Init template
 ##
 ---
 - name: DeployGenericVms.yml
@@ -51,7 +52,7 @@
           GeneralOptions:
             GuestOS: ubuntu64Guest
           BootOptions:
-            Firmware: efi                                             # OPTIONAL - Options are 'bios' or 'efi'
+            Firmware: bios                                            # OPTIONAL - Options are 'bios' or 'efi'
         HardwareSettings:
           Version: latest                                             # Virtual Machine HW version.  If not specified, 'latest' will be used.
           NestedVirtualization: true                                  # Boolean to control the enabling of nested virtualization support
@@ -77,36 +78,36 @@
                   Number:                                             # OPTIONAL - If not specified, it is auto assigned
           Network:
             Adapters:
-              - StartConnected: true
+              - PortGroup: VMNetwork                                  # MANDATORY - Adapters with empty PortGroups will be skipped and not provisioned
                 DeviceType: vmxnet3                                   # MANDATORY - Options: e1000, e1000e, pcnet32, vmxnet2, vmxnet3, sriov
-                PortGroup: VMNetwork                                  # MANDATORY
-              - StartConnected: false
+                StartConnected: true
+              - PortGroup: VMNetwork                                  # MANDATORY - Adapters with empty PortGroups will be skipped and not provisioned
                 DeviceType: vmxnet3                                   # MANDATORY - Options: e1000, e1000e, pcnet32, vmxnet2, vmxnet3, sriov
-                PortGroup: VMNetwork                                  # MANDATORY
-              - StartConnected: false
+                StartConnected: false
+              - PortGroup: VMNetwork                                  # MANDATORY - Adapters with empty PortGroups will be skipped and not provisioned
                 DeviceType: vmxnet3                                   # MANDATORY - Options: e1000, e1000e, pcnet32, vmxnet2, vmxnet3, sriov
-                PortGroup: VMNetwork                                  # MANDATORY
-              - StartConnected: false
+                StartConnected: false
+              - PortGroup: VMNetwork                                  # MANDATORY - Adapters with empty PortGroups will be skipped and not provisioned
                 DeviceType: vmxnet3                                   # MANDATORY - Options: e1000, e1000e, pcnet32, vmxnet2, vmxnet3, sriov
-                PortGroup: VMNetwork                                  # MANDATORY
-              - StartConnected: false
+                StartConnected: false
+              - PortGroup: VMNetwork                                  # MANDATORY - Adapters with empty PortGroups will be skipped and not provisioned
                 DeviceType: vmxnet3                                   # MANDATORY - Options: e1000, e1000e, pcnet32, vmxnet2, vmxnet3, sriov
-                PortGroup: VMNetwork                                  # MANDATORY
-              - StartConnected: false
+                StartConnected: false
+              - PortGroup: VMNetwork                                  # MANDATORY - Adapters with empty PortGroups will be skipped and not provisioned
                 DeviceType: vmxnet3                                   # MANDATORY - Options: e1000, e1000e, pcnet32, vmxnet2, vmxnet3, sriov
-                PortGroup: VMNetwork                                  # MANDATORY
-              - StartConnected: false
+                StartConnected: false
+              - PortGroup: VMNetwork                                  # MANDATORY - Adapters with empty PortGroups will be skipped and not provisioned
                 DeviceType: vmxnet3                                   # MANDATORY - Options: e1000, e1000e, pcnet32, vmxnet2, vmxnet3, sriov
-                PortGroup: VMNetwork                                  # MANDATORY
-              - StartConnected: false
+                StartConnected: false
+              - PortGroup: VMNetwork                                  # MANDATORY - Adapters with empty PortGroups will be skipped and not provisioned
                 DeviceType: vmxnet3                                   # MANDATORY - Options: e1000, e1000e, pcnet32, vmxnet2, vmxnet3, sriov
-                PortGroup: VMNetwork                                  # MANDATORY
-              - StartConnected: false
+                StartConnected: false
+              - PortGroup: VMNetwork                                  # MANDATORY - Adapters with empty PortGroups will be skipped and not provisioned
                 DeviceType: vmxnet3                                   # MANDATORY - Options: e1000, e1000e, pcnet32, vmxnet2, vmxnet3, sriov
-                PortGroup: VMNetwork                                  # MANDATORY
-              - StartConnected: false
+                StartConnected: false
+              - PortGroup: VMNetwork                                  # MANDATORY - Adapters with empty PortGroups will be skipped and not provisioned
                 DeviceType: vmxnet3                                   # MANDATORY - Options: e1000, e1000e, pcnet32, vmxnet2, vmxnet3, sriov
-                PortGroup: VMNetwork                                  # MANDATORY
+                StartConnected: false
         NSXT:
           Tags:
             - Tag: Auto-Deployed
@@ -207,6 +208,11 @@
                   Prefix:
                   Gateway:
           PostInstall:
+            Templates:
+              - Name:                                                                               # Descriptive name for template entry - Entries without names will be skipped
+                Source:                                                                             # REQUIRED - Source Jinja2 template is specified here
+                LocalDestination:                                                                   # REQUIRED - Temporary local destination where the rendered Jinja2 templates are placed, including the filename
+                FinalDestination:                                                                   # REQUIRED - Final location within the VM where the rendered template will be copied to, including the filename
             SSH:
               Server:
                 Install: true
@@ -263,36 +269,36 @@
                   Number:                                             # OPTIONAL - If not specified, it is auto assigned
           Network:
             Adapters:
-              - StartConnected: true
+              - PortGroup: VMNetwork                                  # MANDATORY - Adapters with empty PortGroups will be skipped and not provisioned
                 DeviceType: vmxnet3                                   # MANDATORY - Options: e1000, e1000e, pcnet32, vmxnet2, vmxnet3, sriov
-                PortGroup: VMNetwork                                  # MANDATORY
-              - StartConnected: false
+                StartConnected: true
+              - PortGroup: VMNetwork                                  # MANDATORY - Adapters with empty PortGroups will be skipped and not provisioned
                 DeviceType: vmxnet3                                   # MANDATORY - Options: e1000, e1000e, pcnet32, vmxnet2, vmxnet3, sriov
-                PortGroup: VMNetwork                                  # MANDATORY
-              - StartConnected: false
+                StartConnected: false
+              - PortGroup: VMNetwork                                  # MANDATORY - Adapters with empty PortGroups will be skipped and not provisioned
                 DeviceType: vmxnet3                                   # MANDATORY - Options: e1000, e1000e, pcnet32, vmxnet2, vmxnet3, sriov
-                PortGroup: VMNetwork                                  # MANDATORY
-              - StartConnected: false
+                StartConnected: false
+              - PortGroup: VMNetwork                                  # MANDATORY - Adapters with empty PortGroups will be skipped and not provisioned
                 DeviceType: vmxnet3                                   # MANDATORY - Options: e1000, e1000e, pcnet32, vmxnet2, vmxnet3, sriov
-                PortGroup: VMNetwork                                  # MANDATORY
-              - StartConnected: false
+                StartConnected: false
+              - PortGroup: VMNetwork                                  # MANDATORY - Adapters with empty PortGroups will be skipped and not provisioned
                 DeviceType: vmxnet3                                   # MANDATORY - Options: e1000, e1000e, pcnet32, vmxnet2, vmxnet3, sriov
-                PortGroup: VMNetwork                                  # MANDATORY
-              - StartConnected: false
+                StartConnected: false
+              - PortGroup: VMNetwork                                  # MANDATORY - Adapters with empty PortGroups will be skipped and not provisioned
                 DeviceType: vmxnet3                                   # MANDATORY - Options: e1000, e1000e, pcnet32, vmxnet2, vmxnet3, sriov
-                PortGroup: VMNetwork                                  # MANDATORY
-              - StartConnected: false
+                StartConnected: false
+              - PortGroup: VMNetwork                                  # MANDATORY - Adapters with empty PortGroups will be skipped and not provisioned
                 DeviceType: vmxnet3                                   # MANDATORY - Options: e1000, e1000e, pcnet32, vmxnet2, vmxnet3, sriov
-                PortGroup: VMNetwork                                  # MANDATORY
-              - StartConnected: false
+                StartConnected: false
+              - PortGroup: VMNetwork                                  # MANDATORY - Adapters with empty PortGroups will be skipped and not provisioned
                 DeviceType: vmxnet3                                   # MANDATORY - Options: e1000, e1000e, pcnet32, vmxnet2, vmxnet3, sriov
-                PortGroup: VMNetwork                                  # MANDATORY
-              - StartConnected: false
+                StartConnected: false
+              - PortGroup: VMNetwork                                  # MANDATORY - Adapters with empty PortGroups will be skipped and not provisioned
                 DeviceType: vmxnet3                                   # MANDATORY - Options: e1000, e1000e, pcnet32, vmxnet2, vmxnet3, sriov
-                PortGroup: VMNetwork                                  # MANDATORY
-              - StartConnected: false
+                StartConnected: false
+              - PortGroup: VMNetwork                                  # MANDATORY - Adapters with empty PortGroups will be skipped and not provisioned
                 DeviceType: vmxnet3                                   # MANDATORY - Options: e1000, e1000e, pcnet32, vmxnet2, vmxnet3, sriov
-                PortGroup: VMNetwork                                  # MANDATORY
+                StartConnected: false
         NSXT:
           Tags:
             - Tag: Auto-Deployed
@@ -393,6 +399,11 @@
                   Prefix:
                   Gateway:
           PostInstall:
+            Templates:
+              - Name:                                                                               # Descriptive name for template entry - Entries without names will be skipped
+                Source:                                                                             # REQUIRED - Source Jinja2 template is specified here
+                LocalDestination:                                                                   # REQUIRED - Temporary local destination where the rendered Jinja2 templates are placed, including the filename
+                FinalDestination:                                                                   # REQUIRED - Final location within the VM where the rendered template will be copied to, including the filename
             SSH:
               Server:
                 Install: true

--- a/playbooks/Include_Tasks_DeployGenericVm.yml
+++ b/playbooks/Include_Tasks_DeployGenericVm.yml
@@ -4,16 +4,13 @@
 ##     Filename: playbooks/Include_Tasks_DeployGenericVm.yml
 ##
 ##  Description: This file does the 'heavy lifting' of actually performing the deployment of the Generic VM.
+##               Internet access is required to download updated installer and patches/files from repositories.
+##               All of the installation files are kept within the {{ VMTarget.TempFolder }}/{{ VMTarget.Installer }}
+##               dirctory, simplifying cleanup.  This also will permit parallel deployment of VMs, should that ever
+##               be implemented.
 ##
 ##  ToDo Items:
-##  XX1) If deployed via DHCP, need to obtain the dynamic IP address and then use that to populate DNS.
-##  --2) After deployment, eject ISO from CD-ROM drive
-##  --3) Delete ISO image in ESXi datastore after deployment
-##    4) Apply NSX Tags
-##  --5) Random VMName if field is left empty
-##  --6) Delete 'BOOT' directory in isos folder
-##  --7) Add 'bios' and 'efi' key for OS Adapters
-##    8) Add Jinja2 loop variables in VM structure to support user-specific post-deployment rendering
+##    1) Add Jinja2 loop variables in VM structure to support user-specific post-deployment rendering
 ##
 ---
     - name: Include_Tasks_DeployGenericVm_Playbook
@@ -77,7 +74,6 @@
       when:
         - DEBUG.DisplayVariables
 
-
     - name: Set deployment variables for PHYSICAL target (Physical vCenter or Host)
       ansible.builtin.set_fact:
         VMTarget:
@@ -96,7 +92,7 @@
           SoftwareDirectory: "{{ Software[item.Software.Vendor][item.Software.Product]['Installers'][item.Software.Version]['Location'].Local }}"
           SoftwareFile: "{{ Software[item.Software.Vendor][item.Software.Product]['Installers'][item.Software.Version].File }}"
           SoftwareURL: "{{ Software[item.Software.Vendor][item.Software.Product]['Installers'][item.Software.Version]['Location'].URL }}"
-          SoftwareFileToDeployFrom: "{{ Software[item.Software.Vendor][item.Software.Product]['Installers'][item.Software.Version].File }}-{{ '%03d'|format(loop_idx+1|int) }}"   # Generate unique filename to deploy multiple VMs in parallel
+          SoftwareFileToDeployFrom: "{{ SiteCode }}-VM-{{ '%03d'|format(loop_idx+1|int) }}-{{ Software[item.Software.Vendor][item.Software.Product]['Installers'][item.Software.Version].File }}"   # Generate unique filename to deploy multiple VMs in parallel
         VMInfo:
           VMName: "{% if item.VMName is not none %}{{ item.VMName }}{% else %}{{ SiteCode }}-{{ item.Software.Vendor }}-{{ item.Software.Product}}-{{ item.Software.Version}}-VM-{{ '%03d'|format(loop_idx+1|int) }}{% endif %}"
           FQDN:   "{% if item.VMName is not none %}{{ item.VMName }}.{{ Common.DNS.Domain }}{% else %}{{ SiteCode }}-{{ item.Software.Vendor }}-{{ item.Software.Product}}-{{ item.Software.Version}}-VM-{{ '%03d'|format(loop_idx+1|int) }}.{{ Common.DNS.Domain }}{% endif %}"
@@ -121,7 +117,7 @@
           SoftwareDirectory: "{{ Software[item.Software.Vendor][item.Software.Product]['Installers'][item.Software.Version]['Location'].Local }}"
           SoftwareFile: "{{ Software[item.Software.Vendor][item.Software.Product]['Installers'][item.Software.Version].File }}"
           SoftwareURL: "{{ Software[item.Software.Vendor][item.Software.Product]['Installers'][item.Software.Version]['Location'].URL }}"
-          SoftwareFileToDeployFrom: "{{ Software[item.Software.Vendor][item.Software.Product]['Installers'][item.Software.Version].File }}-{{ '%03d'|format(loop_idx+1|int) }}"   # Generate unique filename to deploy multiple VMs in parallel
+          SoftwareFileToDeployFrom: "{{ SiteCode }}-VM-{{ '%03d'|format(loop_idx+1|int) }}-{{ Software[item.Software.Vendor][item.Software.Product]['Installers'][item.Software.Version].File }}"   # Generate unique filename to deploy multiple VMs in parallel
         VMInfo:
           VMName: "{% if item.VMName is not none %}{{ item.VMName }}{% else %}{{ SiteCode }}-{{ item.Software.Vendor }}-{{ item.Software.Product}}-{{ item.Software.Version}}-VM-{{ '%03d'|format(loop_idx+1|int) }}{% endif %}"
           FQDN:   "{% if item.VMName is not none %}{{ item.VMName }}.{{ Common.DNS.Domain }}{% else %}{{ SiteCode }}-{{ item.Software.Vendor }}-{{ item.Software.Product}}-{{ item.Software.Version}}-VM-{{ '%03d'|format(loop_idx+1|int) }}.{{ Common.DNS.Domain }}{% endif %}"
@@ -264,14 +260,14 @@
         - vm_deployed_status is failed
         - item.Deploy
 
-    - name: Check if Ubuntu ISO file exists locally in the software repository
+    - name: Check if {{ item.Software.Vendor}} {{ item.Software.Product }} {{ item.Software.Version }} ISO file exists locally in the software repository
       ansible.builtin.stat:
         path: "{{ VMTarget.SoftwareDirectory }}/{{ VMTarget.SoftwareFile }}"
       register: InstallerFileCheck
       when:
         - item.Deploy
 
-    - name: Update Ubuntu ISO file in the local software repository (overwrite if exists)
+    - name: Update {{ item.Software.Vendor}} {{ item.Software.Product }} {{ item.Software.Version }} ISO file in the local software repository (overwrite if exists)
       ansible.builtin.get_url:
         url: "{{ VMTarget.SoftwareURL }}/{{ VMTarget.SoftwareFile }}"
         dest: "{{ VMTarget.SoftwareDirectory }}/{{ VMTarget.SoftwareFile }}"
@@ -282,15 +278,15 @@
         - vm_deployed_status is failed
         - item.Deploy
 
-    - name: Extract Ubuntu ISO
-      ansible.builtin.command: "7z -y x {{ VMTarget.SoftwareDirectory }}/{{ VMTarget.SoftwareFile }} -o{{ VMTarget.TempFolder }}/isos/{{ item.Software.Vendor}}_{{ item.Software.Product }}_{{ item.Software.Version }}"
+    - name: Extract {{ item.Software.Vendor}} {{ item.Software.Product }} {{ item.Software.Version }} ISO
+      ansible.builtin.command: "7z -y x {{ VMTarget.SoftwareDirectory }}/{{ VMTarget.SoftwareFile }} -o{{ VMTarget.TempFolder }}/{{ VMTarget.Installer }}/isos/{{ item.Software.Vendor}}_{{ item.Software.Product }}_{{ item.Software.Version }}"
       changed_when: false
       when:
         - vm_deployed_status is failed
         - item.Deploy
 
     - name: Move [BOOT] out of ISO extraction directory
-      ansible.builtin.command: "mv {{ VMTarget.TempFolder }}/isos/{{ item.Software.Vendor}}_{{ item.Software.Product }}_{{ item.Software.Version }}/'[BOOT]' {{ VMTarget.TempFolder }}/isos/BOOT"
+      ansible.builtin.command: "mv {{ VMTarget.TempFolder }}/{{ VMTarget.Installer }}/isos/{{ item.Software.Vendor}}_{{ item.Software.Product }}_{{ item.Software.Version }}/'[BOOT]' {{ VMTarget.TempFolder }}/{{ VMTarget.Installer }}/isos/BOOT"
       changed_when: false
       when:
         - vm_deployed_status is failed
@@ -316,14 +312,14 @@
         - vm_deployed_status is failed
         - item.Deploy
 
-    - name: Create custom Ubuntu ISO
+    - name: Create custom {{ item.Software.Vendor}} {{ item.Software.Product }} {{ item.Software.Version }} ISO
       ansible.builtin.command: "xorriso -as mkisofs -r \
                                 -V '{{ item.Software.Vendor }} {{ item.Software.Version }} AUTO (EFIBIOS)' \
-                                -o {{ VMTarget.TempFolder }}/{{ VMTarget.SoftwareFileToDeployFrom }} \
-                                --grub2-mbr {{ VMTarget.TempFolder }}/isos/BOOT/1-Boot-NoEmul.img  \
+                                -o {{ VMTarget.TempFolder }}/{{ VMTarget.Installer }}/{{ VMTarget.SoftwareFileToDeployFrom }} \
+                                --grub2-mbr {{ VMTarget.TempFolder }}/{{ VMTarget.Installer }}/isos/BOOT/1-Boot-NoEmul.img  \
                                 -partition_offset 16 \
                                 --mbr-force-bootable \
-                                -append_partition 2 28732ac11ff8d211ba4b00a0c93ec93b {{ VMTarget.TempFolder }}/isos/BOOT/2-Boot-NoEmul.img \
+                                -append_partition 2 28732ac11ff8d211ba4b00a0c93ec93b {{ VMTarget.TempFolder }}/{{ VMTarget.Installer }}/isos/BOOT/2-Boot-NoEmul.img \
                                 -appended_part_as_gpt \
                                 -iso_mbr_part_type a2a0d0ebe5b9334487c068b6b72699c7 \
                                 -c '/boot.catalog' \
@@ -332,7 +328,7 @@
                                 -eltorito-alt-boot \
                                 -e '--interval:appended_partition_2:::' \
                                 -no-emul-boot \
-                                {{ VMTarget.TempFolder }}/isos/{{ item.Software.Vendor}}_{{ item.Software.Product }}_{{ item.Software.Version }}/ \
+                                {{ VMTarget.TempFolder }}/{{ VMTarget.Installer }}/isos/{{ item.Software.Vendor}}_{{ item.Software.Product }}_{{ item.Software.Version }}/ \
                                 {{ VMTarget.TempFolder }}/{{ VMTarget.Installer }}/"
       args:
         chdir: "{{ VMTarget.TempFolder }}/{{ VMTarget.Installer }}/"
@@ -348,15 +344,18 @@
       until: result.stdout is search(" 0% packet loss")
       retries: 5
       delay: 3
+      when:
+        - vm_deployed_status is failed
+        - item.Deploy
 
-    - name: Upload the custom Ubuntu ISO to the datastore
+    - name: Upload the custom {{ item.Software.Vendor}} {{ item.Software.Product }} {{ item.Software.Version }} ISO to the datastore
       community.vmware.vsphere_copy:
         hostname: "{{ VMTarget.FQDN }}"
         username: "{{ VMTarget.User }}"
         password: "{{ VMTarget.Password }}"
         validate_certs: "{{ Common.PKI.ValidateCerts }}"
         datacenter: "{{ VMTarget.DataCenter }}"
-        src: "{{ VMTarget.TempFolder }}/{{ VMTarget.SoftwareFileToDeployFrom }}"
+        src: "{{ VMTarget.TempFolder }}/{{ VMTarget.Installer }}/{{ VMTarget.SoftwareFileToDeployFrom }}"
         datastore: "{{ VMTarget.Datastore }}"
         path: "{{ VMTarget.ISOFolder }}/{{ VMTarget.SoftwareFileToDeployFrom }}"
       when:
@@ -428,7 +427,7 @@
 
 
 ##
-## Continue with post-installation configuration items
+## Continue with Runbook post-installation items
 ##
     - name: Set password for the {{ item.OS.Credential.User }} user
       community.vmware.vmware_vm_shell:
@@ -569,36 +568,11 @@
         - item.Deploy
         - runbook.Configuration.Packages != ""
 
-    - name: Delete local ISO extraction directory
-      ansible.builtin.file:
-        path: "{{ VMTarget.TempFolder }}/isos/{{ item.Software.Vendor }}_{{ item.Software.Product }}_{{ item.Software.Version }}"
-        state: absent
-      when:
-        - not DEBUG.KeepInstallerFiles
-
-    - name: Delete local ISO content directory
-      ansible.builtin.file:
-        path: "{{ VMTarget.TempFolder }}/{{ VMTarget.Installer }}"
-        state: absent
-      when:
-        - not DEBUG.KeepInstallerFiles
-        - item.Deploy
-        - vm_deployed_status is failed
-
-    - name: Delete the custom Ubuntu ISO file
-      ansible.builtin.file:
-        path: "{{ VMTarget.TempFolder }}/{{ VMTarget.SoftwareFileToDeployFrom }}"
-        state: absent
-      when:
-        - not DEBUG.KeepInstallerFiles
-        - item.Deploy
-        - vm_deployed_status is failed
-
     - name: Delete configuration files
       ansible.builtin.file:
         path: "{{ runbook_item.LocalDestination }}"
         state: absent
-      loop: "{{ runbook.Configuration.Templates.AfterBoot }}"
+      loop: "{{ runbook.Configuration.Templates.AfterBoot | default([]) }}"
       loop_control:
         loop_var: runbook_item
       when:
@@ -831,6 +805,21 @@
         - vm_deployed_status is failed
         - item.Deploy
 
+    - name: Upgrade installed packages on {{ VMInfo.VMName }} VM
+      community.vmware.vmware_vm_shell:
+        hostname: "{{ VMTarget.FQDN }}"
+        username: "{{ VMTarget.User }}"
+        password: "{{ VMTarget.Password }}"
+        validate_certs: "{{ Common.PKI.ValidateCerts }}"
+        vm_id: "{{ VMInfo.VMName }}"
+        vm_username: "{{ item.OS.Credential.User }}"
+        vm_password: "{{ item.OS.Credential.Password }}"
+        vm_shell: /usr/bin/sudo
+        vm_shell_args: "apt-get -y upgrade"
+      when:
+        - vm_deployed_status is failed
+        - item.Deploy
+
     - name: Install Linux packages on {{ VMInfo.VMName }} VM
       community.vmware.vmware_vm_shell:
         hostname: "{{ VMTarget.FQDN }}"
@@ -849,6 +838,22 @@
         - vm_deployed_status is failed
         - item.Deploy
         - item.OS.PostInstall.Packages is defined
+
+    - name: Remove no longer needed package dependecies from {{ VMInfo.VMName }} VM
+      community.vmware.vmware_vm_shell:
+        hostname: "{{ VMTarget.FQDN }}"
+        username: "{{ VMTarget.User }}"
+        password: "{{ VMTarget.Password }}"
+        validate_certs: "{{ Common.PKI.ValidateCerts }}"
+        vm_id: "{{ VMInfo.VMName }}"
+        vm_username: "{{ item.OS.Credential.User }}"
+        vm_password: "{{ item.OS.Credential.Password }}"
+        vm_shell: /usr/bin/sudo
+        vm_shell_args: "apt-get autoremove"
+      when:
+        - vm_deployed_status is failed
+        - item.Deploy
+
 
 
 #
@@ -916,8 +921,8 @@
         tag_details: false
       register: result
       until: result.instance.hw_power_status == "poweredOff"
-      retries: 60
-      delay: 10
+      retries: 20
+      delay: 5
       when:
         - vm_deployed_status is failed
         - item.Deploy
@@ -971,22 +976,52 @@
 
 
 ##
+## Apply NSX-T Tags & Scopes to Workload VM
+##
+    - name: Update NSX-T Tags on newly deployed Virtual Machine
+      vmware.ansible_for_nsxt.nsxt_vm_tags:
+        hostname: "{{ Nested_NSXT.Component.LocalManager_VIP.FQDN }}"
+        username: "{{ Nested_NSXT.Credential.admin.Name }}"
+        password: "{{ Nested_NSXT.Credential.admin.Password }}"
+        validate_certs: "{{ Common.PKI.ValidateCerts }}"
+        virtual_machine_display_name: "{{ VMInfo.VMName }}"
+        add_tags:
+          - tag: "{{ SingleTag.Tag }}"
+            scope: "{{ SingleTag.Scope }}"
+      register: result
+      loop: "{{ item.NSXT.Tags | default([]) }}"
+      loop_control:
+        loop_var: SingleTag
+      when:
+        - vm_deployed_status is failed
+        - item.Deploy
+        - Deploy.Product.NSXT.LocalManager.Deploy
+        - SingleTag is defined
+        - Deploy.Setting.DeployESXiOnly == false
+
+
+
+##
 ## Deployment Complete - Cleanup environment
 ##
-
-    - name: Refresh DNS cache entry and verify reachability to {{ VMTarget.FQDN }}
+    - name: REMOVE REMOVE REMOVE REMOVE -- Refresh DNS cache entry and verify reachability to {{ VMTarget.FQDN }}
       ansible.builtin.shell:
         cmd: "ping -c 3 {{ VMTarget.FQDN }}"
       register: result
       until: result.stdout is search(" 0% packet loss")
       retries: 5
       delay: 3
+      when:
+        - false
+        - vm_deployed_status is failed
+        - item.Deploy
 
     - name: Delete custom built ISO from the datastore
       community.vmware.vsphere_file:
         hostname: '{{ VMTarget.FQDN }}'
         username: '{{ VMTarget.User }}'
         password: '{{ VMTarget.Password }}'
+        validate_certs: "{{ Common.PKI.ValidateCerts }}"
         datacenter: "{{ VMTarget.DataCenter }}"
         datastore: "{{ VMTarget.Datastore }}"
         path: "{{ VMTarget.ISOFolder }}/{{ VMTarget.SoftwareFileToDeployFrom }}"
@@ -1004,5 +1039,3 @@
         - DEBUG.KeepInstallerFiles is false
         - vm_deployed_status is failed
         - item.Deploy
-
-

--- a/playbooks/Include_Tasks_DeployWorkloadVm.yml
+++ b/playbooks/Include_Tasks_DeployWorkloadVm.yml
@@ -256,6 +256,7 @@
         - SingleTag is defined
         - Deploy.WorkloadVMs.Deploy == true
         - Nested_vCenter.ContentLibrary.WorkloadVMs.Enable == true
+        - Deploy.Setting.DeployESXiOnly == false
 
     - name: DEBUG -- Display 'result' from NSX-T VM Tags for '{{ item.VMName }}'
       ansible.builtin.pause:
@@ -273,6 +274,7 @@
         - result is defined
         - Deploy.WorkloadVMs.Deploy == true
         - Nested_vCenter.ContentLibrary.WorkloadVMs.Enable == true
+        - Deploy.Setting.DeployESXiOnly == false
 
 
 ##

--- a/templates/Ubuntu_Server_24.04/Ubuntu_Server_24.04_vm-hardware.j2
+++ b/templates/Ubuntu_Server_24.04/Ubuntu_Server_24.04_vm-hardware.j2
@@ -15,7 +15,9 @@ disks:
 {% endfor %}{# disk #}
 networks:
 {% for adapter in item.HardwareSettings.Network.Adapters %}
+{%   if adapter.PortGroup is not none %}
   - name: {{ adapter.PortGroup }}
     device_type: {{ adapter.DeviceType }}
     start_connected: {{ adapter.StartConnected }}
-{% endfor %}{# network #}
+{%   endif %}{# PortGroup #}
+{% endfor %}{# adapter #}

--- a/templates/Ubuntu_Server_24.04_runbook.j2
+++ b/templates/Ubuntu_Server_24.04_runbook.j2
@@ -16,7 +16,7 @@ Configuration:
         Source: {{ VMTarget.TemplateFolder }}/{{ item.Software.Vendor}}_{{ item.Software.Product }}_{{ item.Software.Version }}/{{ item.Software.Vendor}}_{{ item.Software.Product }}_{{ item.Software.Version }}_grub.j2
         LocalDestination:
         StageDestination:
-        FinalDestination: {{ VMTarget.TempFolder }}/isos/{{ item.Software.Vendor}}_{{ item.Software.Product }}_{{ item.Software.Version }}/boot/grub/grub.cfg
+        FinalDestination: {{ VMTarget.TempFolder }}/{{ VMTarget.Installer }}/isos/{{ item.Software.Vendor}}_{{ item.Software.Product }}_{{ item.Software.Version }}/boot/grub/grub.cfg
       - Name: UserData
         Source: {{ VMTarget.TemplateFolder }}/{{ item.Software.Vendor}}_{{ item.Software.Product }}_{{ item.Software.Version }}/{{ item.Software.Vendor}}_{{ item.Software.Product }}_{{ item.Software.Version }}_user-data.j2
         LocalDestination:
@@ -30,7 +30,7 @@ Configuration:
     AfterBoot:
       - Name: NetPlan
         Source: {{ VMTarget.TemplateFolder }}/{{ item.Software.Vendor}}_{{ item.Software.Product }}_{{ item.Software.Version }}/{{ item.Software.Vendor}}_{{ item.Software.Product }}_{{ item.Software.Version }}_netplan.j2
-        LocalDestination: {{ VMTarget.TempFolder }}/00-installer-config.yaml
+        LocalDestination: {{ VMTarget.TempFolder }}/{{ VMTarget.Installer }}/00-installer-config.yaml
         StageDestination: /home/{{ item.OS.Credential.User }}/00-installer-config.yaml
         FinalDestination: /etc/netplan/00-installer-config.yaml
   Packages:
@@ -46,7 +46,3 @@ Configuration:
       Owner: nobody:nobody
   Commands:
     - Name: echo '{{ item.OS.Credential.User }} ALL=(ALL) NOPASSWD:ALL' > /target/etc/sudoers.d/ubuntu # Allow user to run sudo without password. Required for successfull post configuration.
-    - Name: apt-get update
-    - Name: apt-get upgrade -y
-    - Name: apt-get autoremove
-    - Name: sync


### PR DESCRIPTION
When deploying a Generic VM, all related files are now placed under the 'Installer' folder, making it easier to clean-up.