### PR TITLE
update createvds to follow software.yml versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2801,3 +2801,13 @@
   - Be Sure to update your:
     - ```software.yml```
     - ```config.yml```
+
+## Dev-v8.0.0 28-OCTOBER-2024
+
+### Added by Aaron Ellis
+  - Updated ```playbooks/CreateVds.yml``` to use the actual vSwitch version value from software when vcenter and esxi were matching.
+    - If there two matched previously the version was not passed and the native vcenter verison of a VDS would be created.  This did not follow what was configured in the software.yml file.
+    Updated ```software_sample.yml``` for ESXi and vCenter 7.0 and newer to reflect the correct maximum vswitch version.
+	- To force a lower vDS version modify your software.yml
+  - Be Sure to update your:
+    - ```software.yml```

--- a/playbooks/CreateVds.yml
+++ b/playbooks/CreateVds.yml
@@ -74,7 +74,7 @@
         datacenter_name: "{{ Nested_vCenter.DataCenter }}"
         validate_certs: "{{ Common.PKI.ValidateCerts }}"
         switch_name: "{{ Nested_vCenter.Networking.vSwitch.Name }}"
-        switch_version: "{% if Deploy.Software.vCenter.vSwitch == Deploy.Software.ESXi.vSwitch %}{{ omit }}\
+        switch_version: "{% if Deploy.Software.vCenter.vSwitch == Deploy.Software.ESXi.vSwitch %}{{ Deploy.Software.vCenter.vSwitch }}\
                          {% else %}{{ Deploy.Software.ESXi.vSwitch }}{% endif %}"
         mtu: "{{ Nested_vCenter.Networking.vSwitch.Config.MTU }}"
         uplink_quantity: "{{ Nested_vCenter.Networking.vSwitch.Config.NumberOfUplinks }}"

--- a/software_sample.yml
+++ b/software_sample.yml
@@ -173,7 +173,7 @@ Software:
             URL:
           Version: "7.0"
           FileExt: iso
-          vSwitch: 7.0.0
+          vSwitch: 7.0.2
         "7.00U2A":
           Name: vCenter Server v7.00 Update 2A
           File: VMware-VCSA-all-7.0.2-17920168.iso
@@ -182,7 +182,7 @@ Software:
             URL:
           Version: "7.0"
           FileExt: iso
-          vSwitch: 7.0.0
+          vSwitch: 7.0.2
         "7.00U2B":
           Name: vCenter Server v7.00 Update 2B
           File: VMware-VCSA-all-7.0.2-17958471.iso
@@ -191,7 +191,7 @@ Software:
             URL:
           Version: "7.0"
           FileExt: iso
-          vSwitch: 7.0.0
+          vSwitch: 7.0.2
         "7.00U2C":
           Name: vCenter Server v7.00 Update 2C
           File: VMware-VCSA-all-7.0.2-18356314.iso
@@ -200,7 +200,7 @@ Software:
             URL:
           Version: "7.0"
           FileExt: iso
-          vSwitch: 7.0.0
+          vSwitch: 7.0.2
         "7.00U2D":
           Name: vCenter Server v7.00 Update 2D
           File: VMware-VCSA-all-7.0.2-18455184.iso
@@ -209,7 +209,7 @@ Software:
             URL:
           Version: "7.0"
           FileExt: iso
-          vSwitch: 7.0.0
+          vSwitch: 7.0.2
         "7.00U3":
           Name: vCenter Server v7.00 Update 3
           File: VMware-VCSA-all-7.0.3-18700403.iso
@@ -218,7 +218,7 @@ Software:
             URL:
           Version: "7.0"
           FileExt: iso
-          vSwitch: 7.0.0
+          vSwitch: 7.0.3
         "7.00U3A":
           Name: vCenter Server v7.00 Update 3A
           File: VMware-VCSA-all-7.0.3-18778458.iso
@@ -227,7 +227,7 @@ Software:
             URL:
           Version: "7.0"
           FileExt: iso
-          vSwitch: 7.0.0
+          vSwitch: 7.0.3
         "7.00U3B":
           Name: vCenter Server v7.00 Update 3B
           File: VMware-VCSA-all-7.0.3-18901211.iso
@@ -236,7 +236,7 @@ Software:
             URL:
           Version: "7.0"
           FileExt: iso
-          vSwitch: 7.0.0
+          vSwitch: 7.0.3
         "7.00U3C":
           Name: vCenter Server v7.00 Update 3C
           File: VMware-VCSA-all-7.0.3-19234570.iso
@@ -245,7 +245,7 @@ Software:
             URL:
           Version: "7.0"
           FileExt: iso
-          vSwitch: 7.0.0
+          vSwitch: 7.0.3
         "7.00U3D":
           Name: vCenter Server v7.00 Update 3D
           File: VMware-VCSA-all-7.0.3-19480866.iso
@@ -254,7 +254,7 @@ Software:
             URL:
           Version: "7.0"
           FileExt: iso
-          vSwitch: 7.0.0
+          vSwitch: 7.0.3
         "7.00U3E":
           Name: vCenter Server v7.00 Update 3E
           File: VMware-VCSA-all-7.0.3-19717403.iso
@@ -263,7 +263,7 @@ Software:
             URL:
           Version: "7.0"
           FileExt: iso
-          vSwitch: 7.0.0
+          vSwitch: 7.0.3
         "7.00U3F":
           Name: vCenter Server v7.00 Update 3F
           File: VMware-VCSA-all-7.0.3-20051473.iso
@@ -272,7 +272,7 @@ Software:
             URL:
           Version: "7.0"
           FileExt: iso
-          vSwitch: 7.0.0
+          vSwitch: 7.0.3
         "7.00U3G":
           Name: vCenter Server v7.00 Update 3G
           File: VMware-VCSA-all-7.0.3-20150588.iso
@@ -281,7 +281,7 @@ Software:
             URL:
           Version: "7.0"
           FileExt: iso
-          vSwitch: 7.0.0
+          vSwitch: 7.0.3
         "7.00U3H":
           Name: vCenter Server v7.00 Update 3H
           File: VMware-VCSA-all-7.0.3-20395099.iso
@@ -290,7 +290,7 @@ Software:
             URL:
           Version: "7.0"
           FileExt: iso
-          vSwitch: 7.0.0
+          vSwitch: 7.0.3
         "7.00U3I":
           Name: vCenter Server v7.00 Update 3I
           File: VMware-VCSA-all-7.0.3-20845200.iso
@@ -299,7 +299,7 @@ Software:
             URL:
           Version: "7.0"
           FileExt: iso
-          vSwitch: 7.0.0
+          vSwitch: 7.0.3
         "7.00U3J":
           Name: vCenter Server v7.00 Update 3J
           File: VMware-VCSA-all-7.0.3-20990077.iso
@@ -308,7 +308,7 @@ Software:
             URL:
           Version: "7.0"
           FileExt: iso
-          vSwitch: 7.0.0
+          vSwitch: 7.0.3
         "7.00U3L":
           Name: vCenter Server v7.00 Update 3L
           File: VMware-VCSA-all-7.0.3-21477706.iso
@@ -317,7 +317,7 @@ Software:
             URL:
           Version: "7.0"
           FileExt: iso
-          vSwitch: 7.0.0
+          vSwitch: 7.0.3
         "7.00U3M":
           Name: vCenter Server v7.00 Update 3M
           File: VMware-VCSA-all-7.0.3-21784236.iso
@@ -326,7 +326,7 @@ Software:
             URL:
           Version: "7.0"
           FileExt: iso
-          vSwitch: 7.0.0
+          vSwitch: 7.0.3
         "8.00":
           Name: vCenter Server v8.00
           File: VMware-VCSA-all-8.0.0-20519528.iso
@@ -335,7 +335,7 @@ Software:
             URL:
           Version: "8.0"
           FileExt: iso
-          vSwitch: 7.0.0
+          vSwitch: 8.0.0
         "8.00A":
           Name: vCenter Server v8.00A
           File: VMware-VCSA-all-8.0.0-20920323.iso
@@ -344,7 +344,7 @@ Software:
             URL:
           Version: "8.0"
           FileExt: iso
-          vSwitch: 7.0.0
+          vSwitch: 8.0.0
         "8.00B":
           Name: vCenter Server v8.00B
           File: VMware-VCSA-all-8.0.0-21216066.iso
@@ -353,7 +353,7 @@ Software:
             URL:
           Version: "8.0"
           FileExt: iso
-          vSwitch: 7.0.0
+          vSwitch: 8.0.0
         "8.00C":
           Name: vCenter Server v8.00C
           File: VMware-VCSA-all-8.0.0-21457384.iso
@@ -362,7 +362,7 @@ Software:
             URL:
           Version: "8.0"
           FileExt: iso
-          vSwitch: 7.0.0
+          vSwitch: 8.0.0
         "8.00U1":
           Name: vCenter Server v8.00 Update 1
           File: VMware-VCSA-all-8.0.1-21560480.iso
@@ -371,7 +371,7 @@ Software:
             URL:
           Version: "8.0"
           FileExt: iso
-          vSwitch: 7.0.0
+          vSwitch: 8.0.0
         "8.00U1A":
           Name: vCenter Server v8.00 Update 1A
           File: VMware-VCSA-all-8.0.1-21815093.iso
@@ -380,7 +380,7 @@ Software:
             URL:
           Version: "8.0"
           FileExt: iso
-          vSwitch: 7.0.0
+          vSwitch: 8.0.0
         "8.00U1B":
           Name: vCenter Server v8.00 Update 1B
           File: VMware-VCSA-all-8.0.1-21860503.iso
@@ -389,7 +389,7 @@ Software:
             URL:
           Version: "8.0"
           FileExt: iso
-          vSwitch: 7.0.0
+          vSwitch: 8.0.0
         "8.00U1C":
           Name: vCenter Server v8.00 Update 1C
           File: VMware-VCSA-all-8.0.1-22088981.iso
@@ -398,7 +398,7 @@ Software:
             URL:
           Version: "8.0"
           FileExt: iso
-          vSwitch: 7.0.0
+          vSwitch: 8.0.0
         "8.00U2":
           Name: vCenter Server v8.00 Update 2
           File: VMware-VCSA-all-8.0.2-22385739.iso
@@ -407,7 +407,7 @@ Software:
             URL:
           Version: "8.0"
           FileExt: iso
-          vSwitch: 7.0.0
+          vSwitch: 8.0.0
         "8.00U2A":
           Name: vCenter Server v8.00 Update 2A
           File: VMware-VCSA-all-8.0.2-22617221.iso
@@ -416,7 +416,7 @@ Software:
             URL:
           Version: "8.0"
           FileExt: iso
-          vSwitch: 7.0.0
+          vSwitch: 8.0.0
         "8.00U2B":
           Name: vCenter Server v8.00 Update 2B
           File: VMware-VCSA-all-8.0.2-23319993.iso
@@ -425,7 +425,7 @@ Software:
             URL:
           Version: "8.0"
           FileExt: iso
-          vSwitch: 7.0.0
+          vSwitch: 8.0.0
         "8.00U2C":
           Name: vCenter Server v8.00 Update 2C
           File: VMware-VCSA-all-8.0.2-23504390.iso
@@ -434,7 +434,7 @@ Software:
             URL:
           Version: "8.0"
           FileExt: iso
-          vSwitch: 7.0.0
+          vSwitch: 8.0.0
         "8.00U3":
           Name: vCenter Server v8.00 Update 3
           File: VMware-VCSA-all-8.0.3-24022515.iso
@@ -443,7 +443,7 @@ Software:
             URL:
           Version: "8.0"
           FileExt: iso
-          vSwitch: 7.0.0
+          vSwitch: 8.0.3
         "8.00U3B":
           Name: vCenter Server v8.00 Update 3B
           File: VMware-VCSA-all-8.0.3-24262322.iso
@@ -452,7 +452,7 @@ Software:
             URL:
           Version: "8.0"
           FileExt: iso
-          vSwitch: 7.0.0
+          vSwitch: 8.0.3
         "8.00U3C":
           Name: vCenter Server v8.00 Update 3C
           File: VMware-VCSA-all-8.0.3-24305161.iso
@@ -461,7 +461,7 @@ Software:
             URL:
           Version: "8.0"
           FileExt: iso
-          vSwitch: 7.0.0
+          vSwitch: 8.0.3
         "8.00U3D":
           Name: vCenter Server v8.00 Update 3D
           File: VMware-VCSA-all-8.0.3-24322831.iso
@@ -470,7 +470,7 @@ Software:
             URL:
           Version: "8.0"
           FileExt: iso
-          vSwitch: 7.0.0
+          vSwitch: 8.0.3
       Patches: []
 
 
@@ -537,7 +537,7 @@ Software:
             URL:
           Version: "7.0"
           FileExt: iso
-          vSwitch: 7.0.0
+          vSwitch: 7.0.2
         "7.00U2A":
           Name: ESXi 7.00 Update 2A
           File: VMware-VMvisor-Installer-7.0U2a-17867351.x86_64.iso
@@ -546,7 +546,7 @@ Software:
             URL:
           Version: "7.0"
           FileExt: iso
-          vSwitch: 7.0.0
+          vSwitch: 7.0.2
         "7.00U3":
           Name: ESXi 7.00 Update 3
           File: VMware-VMvisor-Installer-7.0U3-18644231.x86_64.iso
@@ -555,7 +555,7 @@ Software:
             URL:
           Version: "7.0"
           FileExt: iso
-          vSwitch: 7.0.0
+          vSwitch: 7.0.3
         "7.00U3B":
           Name: ESXi 7.00 Update 3B
           File: VMware-VMvisor-Installer-7.0U3b-18905247.x86_64.iso
@@ -564,7 +564,7 @@ Software:
             URL:
           Version: "7.0"
           FileExt: iso
-          vSwitch: 7.0.0
+          vSwitch: 7.0.3
         "7.00U3C":
           Name: ESXi 7.00 Update 3C
           File: VMware-VMvisor-Installer-7.0U3c-19193900.x86_64.iso
@@ -573,7 +573,7 @@ Software:
             URL:
           Version: "7.0"
           FileExt: iso
-          vSwitch: 7.0.0
+          vSwitch: 7.0.3
         "7.00U3D":
           Name: ESXi 7.00 Update 3D
           File: VMware-VMvisor-Installer-7.0U3d-19482537.x86_64.iso
@@ -582,7 +582,7 @@ Software:
             URL:
           Version: "7.0"
           FileExt: iso
-          vSwitch: 7.0.0
+          vSwitch: 7.0.3
         "7.00U3F":
           Name: ESXi 7.00 Update 3F
           File: VMware-VMvisor-Installer-7.0U3f-20036589.x86_64.iso
@@ -591,7 +591,7 @@ Software:
             URL:
           Version: "7.0"
           FileExt: iso
-          vSwitch: 7.0.0
+          vSwitch: 7.0.3
         "7.00U3G":
           Name: ESXi 7.00 Update 3G
           File: VMware-VMvisor-Installer-7.0U3g-20328353.x86_64.iso
@@ -600,7 +600,7 @@ Software:
             URL:
           Version: "7.0"
           FileExt: iso
-          vSwitch: 7.0.0
+          vSwitch: 7.0.3
         "7.00U3L":
           Name: ESXi 7.00 Update 3L
           File: VMware-VMvisor-Installer-7.0U3l-21424296.x86_64.iso
@@ -609,7 +609,7 @@ Software:
             URL:
           Version: "7.0"
           FileExt: iso
-          vSwitch: 7.0.0
+          vSwitch: 7.0.3
         "8.00":
           Name: ESXi 8.00
           File: VMware-VMvisor-Installer-8.0-20513097.x86_64.iso
@@ -618,7 +618,7 @@ Software:
             URL:
           Version: "8.0"
           FileExt: iso
-          vSwitch: 7.0.0
+          vSwitch: 8.0.0
         "8.00B":
           Name: ESXi 8.00B
           File: VMware-VMvisor-Installer-8.0b-21203435.x86_64.iso
@@ -636,7 +636,7 @@ Software:
             URL:
           Version: "8.0"
           FileExt: iso
-          vSwitch: 7.0.0
+          vSwitch: 8.0.0
         "8.00U1A":
           Name: ESXi 8.00 Update 1A
           File: VMware-VMvisor-Installer-8.0U1a-21813344.x86_64.iso
@@ -645,7 +645,7 @@ Software:
             URL:
           Version: "8.0"
           FileExt: iso
-          vSwitch: 7.0.0
+          vSwitch: 8.0.0
         "8.00U2":
           Name: ESXi 8.00 Update 2
           File: VMware-VMvisor-Installer-8.0U2-22380479.x86_64.iso
@@ -654,7 +654,7 @@ Software:
             URL:
           Version: "8.0"
           FileExt: iso
-          vSwitch: 7.0.0
+          vSwitch: 8.0.0
         "8.00U2B":
           Name: ESXi 8.00 Update 2B
           File: VMware-VMvisor-Installer-8.0U2b-23305546.x86_64.iso
@@ -663,7 +663,7 @@ Software:
             URL:
           Version: "8.0"
           FileExt: iso
-          vSwitch: 7.0.0
+          vSwitch: 8.0.0
         "8.00U3":
           Name: ESXi 8.00 Update 3
           File: VMware-VMvisor-Installer-8.0U3-24022510.x86_64.iso
@@ -672,7 +672,7 @@ Software:
             URL:
           Version: "8.0"
           FileExt: iso
-          vSwitch: 7.0.0
+          vSwitch: 8.0.3
         "8.00U3B":
           Name: ESXi 8.00 Update 3B
           File: VMware-VMvisor-Installer-8.0U3b-24280767.x86_64.iso
@@ -681,7 +681,7 @@ Software:
             URL:
           Version: "8.0"
           FileExt: iso
-          vSwitch: 7.0.0
+          vSwitch: 8.0.3
       Patches: []
 
 


### PR DESCRIPTION
If the software.yml vswitch versions for esxi and vcenter matched no vds version would be passed during the vds creation.  This left only the unintuitive method of only changing the esxi vswitch version if you wanted to change deployment.  Updated software_sample.yml to reflect the proper max/latest version of vds for each and when they match pass the vcenter vds version instead of leaving it blank,  Ideally there would be an override that compared to a list of valid vds versions and the esxi and vcenter versions to ensure compatibility. 