### PR TITLE
Increase RAM in vSphere Edge hosts to 28GB to support NSX v4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2870,3 +2870,9 @@
 ### Added by Rutger Blom
   - Added ```misc/Cloud_Builder_v5.2.1_Example.json``` to the repo which can be used as a reference, for example when deploying a new VCF instance using nested ESXi hosts deployed by SDDC.Lab.
   - Added back the conditional in ```Deploy.yml```to the task importing the ```playbooks/DeploySDDCManager.yml``` playbook. SDDC Manager would typically be deployed together with a Pod to then perform a VCF Import.
+
+## Dev-v8.0.0 11-NOVEMBER-2024
+
+### Added by Luis Chanu
+  - Noticed an issue where not all of the NSX v4.2 EdgeVM nodes are able to power on due to memory constraints.  To mitigate this, incrased memory on vSphere Edge cluster hosts memory from 20GB to 28GB in ```config_sample.yml```.
+  - Be sure to update your ```config.yml``` file(s).

--- a/config_sample.yml
+++ b/config_sample.yml
@@ -1183,7 +1183,7 @@ Nested_ESXi:
     Edge:
       CPU: 8
       CoresPerSocket: 8
-      Memory: 20480
+      Memory: 28672
       BootDiskSize: 16
       vSAN:
         CacheSize: 20                                                                   # CacheSize and CapacitySize MUST be different values.  Normally, CacheSize is smaller than CapacitySize.


### PR DESCRIPTION
Addresses issue with all NSX v4.2 Edge VM nodes not deploying.