### PR TITLE
Updated physical vCenter vDS version from 6.6.0 to 8.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2945,3 +2945,4 @@
   - Updated ```TargetConfig.vCenter.vSwitchVersion``` in ```config_sample.yml``` from version ```6.6.0``` to ```8.0.3```.  Assumption is that users are running vSphere 8.0 Update 3 on their physical hosts.
   - Be sure to update your:
     - ```config.yml``` files
+  - Added DHCPv4 scope for ```Transport``` VLAN.  As with other DHCP scopes, the router is handing out .200-.254 addresses.  This is to help facilitate the VCF deployments w/o the use of a JSON file.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2938,3 +2938,10 @@
 
 ### Added by Luis Chanu
   - Modified ```playbooks\DeployNestedEsxi.yml``` playbook to provision ESXi hosts with 8 vNICs instead of 5.  This is to support the testing of advanced NIC deploymet scenarios from within VCF.
+
+## Dev-v8.0.0 12-DECEMBER-2024
+
+### Added by Luis Chanu
+  - Updated ```TargetConfig.vCenter.vSwitchVersion``` in ```config_sample.yml``` from version ```6.6.0``` to ```8.0.3```.  Assumption is that users are running vSphere 8.0 Update 3 on their physical hosts.
+  - Be sure to update your:
+    - ```config.yml``` files

--- a/config_sample.yml
+++ b/config_sample.yml
@@ -320,7 +320,7 @@ TargetConfig:
     User: administrator@vsphere.local                                         # User - vCenter Server user account.  We suggest you create a dedicated account for deployments, such as SDDCLab@vsphere.local.  If using Content Libraries, user must be given persmission to the respective Content Library
     Password: "{{ Common.Password.Physical }}"                                # Password - Password used by User to authenticate to the physical vCenter Server
     vSwitch: SDDCLab_vDS                                                      # vSwitch - Name of the vDS which is automatically provisioned by the playbooks, and where all the Pod Port-Groups are crated
-    vSwitchVersion: 6.6.0                                                     # vSwitchVersion - vDS version used for the given vSwitch
+    vSwitchVersion: 8.0.3                                                     # vSwitchVersion - vDS version used for the given vSwitch.  If not running v8.0 Update 3 (or later), change to the version your environment supports.
     DataCenter: SDDC                                                          # DataCenter - Defines under which DataCenter object the lab Pod's are deployed
     Cluster: Lab-Cluster                                                      # Cluster - Defines which vSphere cluster within DataCenter the lab Pod's are deployed
     Datastore: Shared_VMs                                                     # Datastore - Defines Which datastore should the nested lab Pod VMs be placed

--- a/templates/vyos_router.j2
+++ b/templates/vyos_router.j2
@@ -235,6 +235,8 @@ set service ssh port 22
 ## Serivce - DHCPv4
 ##
 {% if Deploy.Setting.IPv4 -%}
+
+# ServiceVM
 set service dhcp-server shared-network-name servicevm authoritative
 set service dhcp-server shared-network-name servicevm subnet {{ Nested_Router.Interface.ServiceVM.IPv4.Address | ansible.utils.ipsubnet( Nested_Router.Interface.ServiceVM.IPv4.Prefix ) }} option default-router {{ Nested_Router.Interface.ServiceVM.IPv4.Address }}
 set service dhcp-server shared-network-name servicevm subnet {{ Nested_Router.Interface.ServiceVM.IPv4.Address | ansible.utils.ipsubnet( Nested_Router.Interface.ServiceVM.IPv4.Prefix ) }} option name-server {{ Common.DNS.Server1.IPv4 }}
@@ -243,6 +245,7 @@ set service dhcp-server shared-network-name servicevm subnet {{ Nested_Router.In
 set service dhcp-server shared-network-name servicevm subnet {{ Nested_Router.Interface.ServiceVM.IPv4.Address | ansible.utils.ipsubnet( Nested_Router.Interface.ServiceVM.IPv4.Prefix ) }} range ServiceVMRange stop  {{ Net.ServiceVM.IPv4.Network }}.254
 set service dhcp-server shared-network-name servicevm subnet {{ Nested_Router.Interface.ServiceVM.IPv4.Address | ansible.utils.ipsubnet( Nested_Router.Interface.ServiceVM.IPv4.Prefix ) }} subnet-id {{ Net.ServiceVM.VLAN }}
 
+# VMNetwork
 set service dhcp-server shared-network-name vmnetwork authoritative
 set service dhcp-server shared-network-name vmnetwork subnet {{ Nested_Router.Interface.VMNetwork.IPv4.Address | ansible.utils.ipsubnet( Nested_Router.Interface.VMNetwork.IPv4.Prefix ) }} option default-router {{ Nested_Router.Interface.VMNetwork.IPv4.Address }}
 set service dhcp-server shared-network-name vmnetwork subnet {{ Nested_Router.Interface.VMNetwork.IPv4.Address | ansible.utils.ipsubnet( Nested_Router.Interface.VMNetwork.IPv4.Prefix ) }} option name-server {{ Common.DNS.Server1.IPv4 }}
@@ -250,6 +253,15 @@ set service dhcp-server shared-network-name vmnetwork subnet {{ Nested_Router.In
 set service dhcp-server shared-network-name vmnetwork subnet {{ Nested_Router.Interface.VMNetwork.IPv4.Address | ansible.utils.ipsubnet( Nested_Router.Interface.VMNetwork.IPv4.Prefix ) }} range VMNetworkRange start {{ Net.VMNetwork.IPv4.Network }}.200
 set service dhcp-server shared-network-name vmnetwork subnet {{ Nested_Router.Interface.VMNetwork.IPv4.Address | ansible.utils.ipsubnet( Nested_Router.Interface.VMNetwork.IPv4.Prefix ) }} range VMNetworkRange stop  {{ Net.VMNetwork.IPv4.Network }}.254
 set service dhcp-server shared-network-name vmnetwork subnet {{ Nested_Router.Interface.VMNetwork.IPv4.Address | ansible.utils.ipsubnet( Nested_Router.Interface.VMNetwork.IPv4.Prefix ) }} subnet-id {{ Net.VMNetwork.VLAN }}
+
+# GENEVE Overlay Transport (i.e. TEPs)
+set service dhcp-server shared-network-name transport authoritative
+set service dhcp-server shared-network-name transport subnet {{ Nested_Router.Interface.Transport.IPv4.Address | ansible.utils.ipsubnet( Nested_Router.Interface.Transport.IPv4.Prefix ) }} option default-router {{ Nested_Router.Interface.Transport.IPv4.Address }}
+set service dhcp-server shared-network-name transport subnet {{ Nested_Router.Interface.Transport.IPv4.Address | ansible.utils.ipsubnet( Nested_Router.Interface.Transport.IPv4.Prefix ) }} option name-server {{ Common.DNS.Server1.IPv4 }}
+set service dhcp-server shared-network-name transport subnet {{ Nested_Router.Interface.Transport.IPv4.Address | ansible.utils.ipsubnet( Nested_Router.Interface.Transport.IPv4.Prefix ) }} lease 300
+set service dhcp-server shared-network-name transport subnet {{ Nested_Router.Interface.Transport.IPv4.Address | ansible.utils.ipsubnet( Nested_Router.Interface.Transport.IPv4.Prefix ) }} range TransportRange start {{ Net.Transport.IPv4.Network }}.200
+set service dhcp-server shared-network-name transport subnet {{ Nested_Router.Interface.Transport.IPv4.Address | ansible.utils.ipsubnet( Nested_Router.Interface.Transport.IPv4.Prefix ) }} range TransportRange stop  {{ Net.Transport.IPv4.Network }}.254
+set service dhcp-server shared-network-name transport subnet {{ Nested_Router.Interface.Transport.IPv4.Address | ansible.utils.ipsubnet( Nested_Router.Interface.Transport.IPv4.Prefix ) }} subnet-id {{ Net.Transport.VLAN }}
 
 {% endif -%}{# Deploy.Setting.IPv4 #}
 


### PR DESCRIPTION
If you are not running vSphere 8.0 Update 3 (or later), set this to the vDS version that your vSphere supports.  Additional comments were added to the right side of the setting to notify the user of that as well.