### PR TITLE
Remove 'RouteRedistributionConfig' from all T1 Gateways in config_sample.yml file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3007,3 +3007,9 @@
   - Be sure to update your:
     - ```software.yml```
     - ```config.yml```
+
+## Dev-v8.0.0 29-DECEMBER-2024
+
+### Added by Luis Chanu
+  - Removed the ```Nested_NSXT.Networking.Tier1Gateways.LocaleServices.RouteRedistributionConfig``` section from each T1 Gateway in the ```config_sample.yml``` file, as this section was not being used.
+  - Be sure to update your ```config.yml``` file.

--- a/README.md
+++ b/README.md
@@ -515,7 +515,9 @@ As we use SDDC.Lab in our labs, every now-and-then we notice some issues/problem
 | 11-OCT-2022 | 8.0.0 (Build  20519528) | 8.0.0 (Build 20513097) | 4.0.0.1 | Although v8.0.0 of vCenter Server and ESXi deploy successfully using SDDC.Lab, NSX fails when it attempts to apply the Transport Node Profile to the vSphere cluster.  It fails with the following error message, "```NSX cannot be enabled on the cluster because it contains host 6e6954ea-2f6a-491a-a3d4-34ea27078709:host-14 of unsupported version.```"  So, it appears the next version of NSX is required in order to support vSphere 8.0.0 (GA). | Luis Chanu |
 | 14-OCT-2022 | 8.0.0 (Build  20519528) | 8.0.0 (Build 20513097) | 4.0.1.1 | NSX-T Federation deployment is not supported due to a Federation onboarding bug with NSX where the Segment paths are not correct within vCenter Server. | Luis Chanu |
 | 26-APR-2023 | 7.0.0U3L | 7.0.0U3L | 3.2.2.1 | NSX-T Federation deployment is not supported due to a Federation onboarding bug with NSX where the Segment paths are not correct within vCenter Server.  This is the same issue discovered with NSX v4.0.1.1.  | Luis Chanu |
-| 09-JUL-2024 | N/A | N/A | N/A | PIP3 ansible package v10.1.0 causes ```"/bin/sh: 1: /usr/bin/env python: not found\n"``` failure during deployment.  Solution is to install ansible package v9.7.0. | Luis Chanu |
+| 09-JUL-2024 | N/A | N/A | N/A | PIP3 ansible package v10.1.0 causes ```"/bin/sh: 1: /usr/bin/env python: not found\n"``` failure during deployment.  Solution is to install ansible package v9.7.0. UPDATE: This issue was corrected by the maintainers of the VMware Ansible Modules, and is resolved in ```community.vmware``` module version 5.2.0 | Luis Chanu |
+| 29-DEC-2024 | N/A | N/A | N/A | vRLI v8.18.0 fails during SDDC.Lab deployment.  Solution is to use a different vRLI version. | Luis Chanu |
+
 
 ## More Information
 For detailed installation, preparation, and deployment steps, please see the "[Deploying your first SDDC.Lab Pod](FirstPod.md)" document.

--- a/config_sample.yml
+++ b/config_sample.yml
@@ -2498,13 +2498,6 @@ Nested_NSXT:
                 Scope: SDDC.Lab
             EdgeCluster:
               Name: ""
-            RouteRedistributionConfig:
-              BGP_Enabled: true
-              Rules:
-                - Name: Redistribute Connected
-                  Types:                                                                        # Types include TIER0_STATIC, TIER0_CONNECTED, TIER0_EXTERNAL_INTERFACE, TIER0_LOOPBACK_INTERFACE, TIER0_SEGMENT, TIER0_ROUTER_LINK, TIER0_SERVICE_INTERFACE, TIER0_DNS_FORWARDER_IP, TIER0_IPSEC_LOCAL_IP, TIER0_NAT, TIER0_EVPN_TEP_IP, TIER1_STATIC_ROUTES, TIER1_NAT, TIER1_LB_VIP, TIER1_LB_SNAT, TIER1_DNS_FORWARDER_IP, TIER1_CONNECTED, TIER1_SERVICE_INTERFACE, TIER1_SEGMENT, TIER1_IPSEC_LOCAL_ENDPOINT
-                    - TIER1_CONNECTED
-                    - TIER1_SEGMENT
       - Name:           T1-Gateway-ALB-Management
         Description:    Tier-1 Gateway for Advanced Load Balancer in SDDC.Lab
         FailoverMode:   NON_PREEMPTIVE                                                          # Options are "NON_PREEMPTIVE" or "PREEMPTIVE"
@@ -2524,13 +2517,6 @@ Nested_NSXT:
                 Scope: SDDC.Lab
             EdgeCluster:
               Name: ""
-            RouteRedistributionConfig:
-              BGP_Enabled: true
-              Rules:
-                - Name: Redistribute Connected
-                  Types:                                                                        # Types include TIER0_STATIC, TIER0_CONNECTED, TIER0_EXTERNAL_INTERFACE, TIER0_LOOPBACK_INTERFACE, TIER0_SEGMENT, TIER0_ROUTER_LINK, TIER0_SERVICE_INTERFACE, TIER0_DNS_FORWARDER_IP, TIER0_IPSEC_LOCAL_IP, TIER0_NAT, TIER0_EVPN_TEP_IP, TIER1_STATIC_ROUTES, TIER1_NAT, TIER1_LB_VIP, TIER1_LB_SNAT, TIER1_DNS_FORWARDER_IP, TIER1_CONNECTED, TIER1_SERVICE_INTERFACE, TIER1_SEGMENT, TIER1_IPSEC_LOCAL_ENDPOINT
-                    - TIER1_CONNECTED
-                    - TIER1_SEGMENT
       - Name:           T1-Gateway-ALB-Data
         Description:    Tier-1 Gateway for Advanced Load Balancer in SDDC.Lab
         FailoverMode:   NON_PREEMPTIVE                                                          # Options are "NON_PREEMPTIVE" or "PREEMPTIVE"
@@ -2550,13 +2536,6 @@ Nested_NSXT:
                 Scope: SDDC.Lab
             EdgeCluster:
               Name: ""
-            RouteRedistributionConfig:
-              BGP_Enabled: true
-              Rules:
-                - Name: Redistribute Connected
-                  Types:                                                                        # Types include TIER0_STATIC, TIER0_CONNECTED, TIER0_EXTERNAL_INTERFACE, TIER0_LOOPBACK_INTERFACE, TIER0_SEGMENT, TIER0_ROUTER_LINK, TIER0_SERVICE_INTERFACE, TIER0_DNS_FORWARDER_IP, TIER0_IPSEC_LOCAL_IP, TIER0_NAT, TIER0_EVPN_TEP_IP, TIER1_STATIC_ROUTES, TIER1_NAT, TIER1_LB_VIP, TIER1_LB_SNAT, TIER1_DNS_FORWARDER_IP, TIER1_CONNECTED, TIER1_SERVICE_INTERFACE, TIER1_SEGMENT, TIER1_IPSEC_LOCAL_ENDPOINT
-                    - TIER1_CONNECTED
-                    - TIER1_SEGMENT
 
     DHCPProfiles:
       - Name: DHCP-Server-Profile                                                               # The first profile is used by the DHCP Local Server to provide IP's to all Overlay Segments


### PR DESCRIPTION
The RouteRedistributionConfig section in the config.yml file was not needed/used, so it was removed.