### PR TITLE
add var to ansible hosts file to support python venvs.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3070,3 +3070,9 @@
   - Added NSX 4.2.1.2 to ```software_sample.yml``` (NOT TESTED)
   - Be sure to update your:
     - ```software.yml```
+
+## Dev-v8.0.0 27-JANUARY-2025
+
+### Added by Aaron Ellis
+  - updated ansible hosts file localhost vars to use the calling python exe path.  Supports python venvs.
+  

--- a/hosts/hosts
+++ b/hosts/hosts
@@ -1,2 +1,2 @@
 [defaults]
-localhost ansible_connection=local
+localhost	ansible_connection=local	ansible_python_interpreter="{{ ansible_playbook_python }}"


### PR DESCRIPTION
pip added a feature to warn and block you before installing packages that could break things that ship in distro repos.  Started using a python venv and realized that the localhost connections, while set to local for the connection method were using the system python for calls which did not have all the pip packages installed.  This var makes the local "loopback" connections consume the path to python that was used for the initial call instead of the system default python path.   It will work for both venvs and if someone has installed pip packages on the system. 