### PR TITLE
change VyOS router shutdown to in-guest cli commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3075,4 +3075,9 @@
 
 ### Added by Aaron Ellis
   - updated ansible hosts file localhost vars to use the calling python exe path.  Supports python venvs.
+
+## Dev-v8.0.0 28-JANUARY-2025
+
+### Added by Aaron Ellis
+  - Updated ```DeployRouter.yml``` to issue poweroff command in the cli instead of relying on vmtools guest shutdown.
   

--- a/playbooks/DeployRouter.yml
+++ b/playbooks/DeployRouter.yml
@@ -670,14 +670,66 @@
         - Deploy.Product.Router.Deploy
         - status is failed
 
-    - name: Shutdown VyOS VM
-      community.vmware.vmware_guest_powerstate:
+    - name: Shutdown VyOS VM in-guest (Enter 'poweroff' on cli)
+      community.vmware.vmware_guest_sendkey:
         hostname: "{{ Target.FQDN }}"
         username: "{{ Target.User }}"
         password: "{{ Target.Password }}"
         validate_certs: "{{ Common.PKI.ValidateCerts }}"
         name: "{{ Nested_Router.Name }}"
-        state: shutdown-guest
+        string_send: "poweroff"
+      when:
+        - Deploy.Product.Router.Deploy
+        - status is failed
+
+    - name: Wait 10 seconds
+      ansible.builtin.pause:
+        seconds: 10
+      when:
+        - Deploy.Product.Router.Deploy
+        - status is failed
+
+    - name: Shutdown VyOS vm in-guest Press 'ENTER' after 'poweroff' on cli)
+      community.vmware.vmware_guest_sendkey:
+        hostname: "{{ Target.FQDN }}"
+        username: "{{ Target.User }}"
+        password: "{{ Target.Password }}"
+        validate_certs: "{{ Common.PKI.ValidateCerts }}"
+        name: "{{ Nested_Router.Name }}"
+        keys_send:
+          - ENTER
+      when:
+        - Deploy.Product.Router.Deploy
+        - status is failed
+
+    - name: Shutdown VyOS VM in-guest (Enter 'y' to are you sure prompt)
+      community.vmware.vmware_guest_sendkey:
+        hostname: "{{ Target.FQDN }}"
+        username: "{{ Target.User }}"
+        password: "{{ Target.Password }}"
+        validate_certs: "{{ Common.PKI.ValidateCerts }}"
+        name: "{{ Nested_Router.Name }}"
+        string_send: "y"
+      when:
+        - Deploy.Product.Router.Deploy
+        - status is failed
+
+    - name: Wait 10 seconds
+      ansible.builtin.pause:
+        seconds: 10
+      when:
+        - Deploy.Product.Router.Deploy
+        - status is failed
+
+    - name: Shutdown VyOS vm in-guest Press 'ENTER' after 'y' on cli)
+      community.vmware.vmware_guest_sendkey:
+        hostname: "{{ Target.FQDN }}"
+        username: "{{ Target.User }}"
+        password: "{{ Target.Password }}"
+        validate_certs: "{{ Common.PKI.ValidateCerts }}"
+        name: "{{ Nested_Router.Name }}"
+        keys_send:
+          - ENTER
       when:
         - Deploy.Product.Router.Deploy
         - status is failed


### PR DESCRIPTION
VyOS removed all in-gust vm agents from their generic image as of Dec 6 2024.  https://vyos.dev/T6942
Added sending the in-guest poweroff command and prompt answers to the end of the existing install workflow since that was the only tools dependency I could find.  You can install tools via apt, but I did not want to assume labs were internet connected.  This change will also be backward compatible for older versions of VyOS that have tools installed. 