### PR TITLE
Added 'open-vm-tools' installation to Pod-Router

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3100,3 +3100,9 @@
   - Added an example Pod-Router UserConfig file to ```misc/Router-UserConfig``` directory.
   - Updated ```README.md``` file to indicate that an example file has been added.
   - Updated ```playbooks/CreatePodConfig.yml``` playbook to include ```VYOS_``` to static Pod Configuration file.
+
+## Dev-v8.0.0 11-MARCH-2025
+
+### Added by Luis Chanu
+  - VyOS recently removed ```open-vm-tools``` from the VyOS nightly-build ISO image.  Added tasks to re-install ```open-vm-tools``` as part of the VyOS Pod-Router deployment.
+  - Added check for, and installation of, ```open-vm-tools``` to ```playbooks/ConfigureRouter.yml``` playbook.  In order to install ```open-vm-tools```, Internet access is required.  If Internet access is not available, the errors are ignored, and the SDDC.Lab installation proceeds without ```open-vm-tools``` installed.

--- a/playbooks/ConfigureRouter.yml
+++ b/playbooks/ConfigureRouter.yml
@@ -288,3 +288,36 @@
 
           =====================================================================================================
       when: '" 0% packet loss" not in result.stdout'
+
+
+##
+## Install open-vm-tools from Internet (Ignoring failures)
+##
+    - name: Check to see if open-vm-tools is already running
+      vyos.vyos.vyos_command:
+        commands:
+          - systemctl status open-vm-tools
+      vars:
+        ansible_connection: ansible.netcommon.network_cli
+        ansible_host: "{{ Nested_Router.Interface.Uplink.IPv4.Address }}"
+        ansible_user: vyos
+        ansible_password: "{{ Common.Password.Nested }}"
+        ansible_network_os: vyos.vyos.vyos
+      register: result
+
+    - name: Install open-vm-tools on VyOS router if 'active (running)' state not found in 'result'
+      vyos.vyos.vyos_command:
+        commands:
+          - echo 'deb https://deb.debian.org/debian bookworm main non-free-firmware'     | sudo tee -a /etc/apt/sources.list
+          - echo 'deb-src https://deb.debian.org/debian bookworm main non-free-firmware' | sudo tee -a /etc/apt/sources.list
+          - sudo apt-get -y update
+          - sudo apt-get -y install open-vm-tools
+      vars:
+        ansible_connection: ansible.netcommon.network_cli
+        ansible_host: "{{ Nested_Router.Interface.Uplink.IPv4.Address }}"
+        ansible_user: vyos
+        ansible_password: "{{ Common.Password.Nested }}"
+        ansible_network_os: vyos.vyos.vyos
+      ignore_errors: true
+      when:
+        - '"active (running)" not in result.stdout[0]'


### PR DESCRIPTION
This PR installs 'open-vm-tools' onto the VyOS router, thereby allowing it to be managed.  Re-introduces clean shutdown of the VM via vCenter/ESXi host.