### PR TITLE
Correct DNS_Records issue with only IPv4 entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3137,3 +3137,8 @@
   - Updated ```README.md``` file.
   - Be sure to update your:
     - ```config.yml```
+
+## Dev-v8.0.0 16-APRIL-2025
+
+### Added by Luis Chanu
+  - Corrected issue in ```playbooks/UpdateDNS.yml``` and ```playbooks/CleanupDNS.yml``` playbooks when ```DNS_Records``` only contains IPv4 addresses.

--- a/playbooks/CleanupDNS.yml
+++ b/playbooks/CleanupDNS.yml
@@ -2031,6 +2031,7 @@
         - Deploy.Setting.IPv6
         - item.Name      | default(None) is not none
         - item.Addresses | default(None) is not none
+        - item.Addresses | ansible.utils.ipv6 | ansible.utils.ipaddr('address') | length > 0
         - item.Addresses | ansible.utils.ipv6 | ansible.utils.ipaddr('address') | first | length > 0
 
     - name: IPv6 'AAAA' records for DNS_Records (Only first IPv6 address)
@@ -2048,6 +2049,7 @@
         - Deploy.Setting.IPv6
         - item.Name      | default(None) is not none
         - item.Addresses | default(None) is not none
+        - item.Addresses | ansible.utils.ipv6 | ansible.utils.ipaddr('address') | length > 0
         - item.Addresses | ansible.utils.ipv6 | ansible.utils.ipaddr('address') | first | length > 0
 
     - name: DEBUG -- Display IPv6 'PTR' record for Nested_Replication (All IPv6 addresses)

--- a/playbooks/UpdateDNS.yml
+++ b/playbooks/UpdateDNS.yml
@@ -2041,6 +2041,7 @@
         - Deploy.Setting.IPv6
         - item.Name      | default(None) is not none
         - item.Addresses | default(None) is not none
+        - item.Addresses | ansible.utils.ipv6 | ansible.utils.ipaddr('address') | length > 0
         - item.Addresses | ansible.utils.ipv6 | ansible.utils.ipaddr('address') | first | length > 0
 
     - name: IPv6 'AAAA' records for DNS_Records (Only first IPv6 address)
@@ -2058,6 +2059,7 @@
         - Deploy.Setting.IPv6
         - item.Name      | default(None) is not none
         - item.Addresses | default(None) is not none
+        - item.Addresses | ansible.utils.ipv6 | ansible.utils.ipaddr('address') | length > 0
         - item.Addresses | ansible.utils.ipv6 | ansible.utils.ipaddr('address') | first | length > 0
 
     - name: DEBUG -- Display IPv6 'PTR' record for Nested_Replication (All IPv6 addresses)


### PR DESCRIPTION
When DNS_Records only contains IPv4 entries, the task creating the first IPv6 record would fail because there is no 'first' IPv6 entry to process.  This fix corrects that.